### PR TITLE
Fixed bug #665

### DIFF
--- a/src/main/java/com/InfinityRaider/AgriCraft/blocks/BlockWaterTank.java
+++ b/src/main/java/com/InfinityRaider/AgriCraft/blocks/BlockWaterTank.java
@@ -1,6 +1,7 @@
 package com.InfinityRaider.AgriCraft.blocks;
 
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
@@ -52,7 +53,12 @@ public class BlockWaterTank extends BlockCustomWood {
 							if (stack.getItem().hasContainerItem(stack)) {
 								player.inventory.setInventorySlotContents(player.inventory.currentItem, stack.getItem().getContainerItem(stack));
 							} else {
-								player.inventory.setInventorySlotContents(player.inventory.currentItem, null);
+								// give the player a glass bottle if he filled the tank with a water bottle
+								if (stack.getItem().getItemStackDisplayName(stack).equals(stack.getItem().getItemStackDisplayName(new ItemStack(Items.potionitem)))) {
+									player.inventory.setInventorySlotContents(player.inventory.currentItem, new ItemStack(Items.glass_bottle));
+								} else {
+									player.inventory.setInventorySlotContents(player.inventory.currentItem, null);
+								}
 							}
 						} else {
 							stack.splitStack(1);


### PR DESCRIPTION
Added a check when filling the tank with water that checks if the player
uses a water bottle and gives back a glass bottle in that case. This check
is needed because water bottles do NOT have a container item as for example (water) buckets have which would usually lead to the 'deletion' of the bottle like shown in issue AgriCraft/AgriCraft#665.

I also realized that when removing water from the tank with stacked items (buckets & bottles) the new items do not appear in the inventory, you first have to click on them to become visible. I suppose this is because of the markDirty call on the inventory (l. 93), but I was not sure about that so I'll leave it as it is.