### PR TITLE
Right clicking crops with plants uses crop sticks

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/tiles/TileEntityCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/tiles/TileEntityCrop.java
@@ -107,10 +107,11 @@ public class TileEntityCrop extends TileEntityBase implements IAgriCrop, IDebugg
                 return true;
             } //check to see if the player clicked with crops (crosscrop attempt)
             else if (heldItem.getItem() == AgriItems.getInstance().CROPS) {
-                if (!this.isCrossCrop() && !player.isCreative()) {
+                if (!this.isCrossCrop() && !this.hasPlant() && !player.isCreative()) {
                     heldItem.stackSize--;
+                    this.setCrossCrop(true);
                 }
-                this.setCrossCrop(true);
+                
             } else {
                 //harvest operation
                 this.onHarvested(player);


### PR DESCRIPTION
Currently right clicking a crop that has a plant will consume crop sticks from your inventory. This fixes that. I also moved the setCrossCrop(true) into the conditional as it only made sense to set it to true if a crossCrop was actually placed i.e. the stack count went down.