### PR TITLE
Fix BlockCrop::canBlockStay pos.down() typo

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/blocks/BlockCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/blocks/BlockCrop.java
@@ -249,7 +249,7 @@ public class BlockCrop extends BlockTileCustomRenderedBase<TileEntityCrop> imple
      * @return if the crop is placed in a valid location.
      */
     public boolean canBlockStay(IBlockAccess world, BlockPos pos) {
-        return AgriApi.getSoilRegistry().contains(world.getBlockState(pos));
+        return AgriApi.getSoilRegistry().contains(world.getBlockState(pos.down()));
     }
 
     /**


### PR DESCRIPTION
Also known as calming down some jumpy crops. An update earlier today in
canBlockStay left off the .down() offset, which meant that the the soil
check would always fail. And since canBlockStay is only called by
neighborChanged, the crops would be stable until an update happened.