### PR TITLE
Fixing up sprinklers

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/api/v1/util/BlockRange.java
+++ b/src/main/java/com/infinityraider/agricraft/api/v1/util/BlockRange.java
@@ -133,26 +133,28 @@ public class BlockRange implements Iterable<BlockPos> {
 
         private int x, y, z;
         private final BlockRange range;
+        private boolean hasMoreBlocks; 
 
         public BlockRangeIterator(@Nonnull BlockRange range) {
             this.range = Objects.requireNonNull(range, "You cannot iterate over a range that doesn't exist!");
             this.x = range.minX;
             this.y = range.minY;
             this.z = range.minZ;
+            this.hasMoreBlocks = this.x <= range.maxX
+                              && this.y <= range.maxY
+                              && this.z <= range.maxZ;
         }
 
         @Override
         public boolean hasNext() {
-            return this.x <= this.range.getMaxX()
-                    && this.y <= this.range.getMaxY()
-                    && this.z <= this.range.getMaxZ();
+            return hasMoreBlocks; 
         }
 
         @Nonnull
         @Override
         public BlockPos next() {
             // Ensure haven't fallen out of bounds.
-            if (!hasNext()) {
+            if (!hasMoreBlocks) {
                 throw new IndexOutOfBoundsException();
             }
 
@@ -160,13 +162,16 @@ public class BlockRange implements Iterable<BlockPos> {
             final BlockPos pos = new BlockPos(x, y, z);
 
             // Post-Increment
+            // Note: ordered by y-level
             this.x += 1;
             if (this.x > this.range.getMaxX()) {
-                this.x -= 1;
-                this.y += 1;
-                if (this.y > this.range.getMaxY()) {
-                    this.y -= 1;
-                    this.z += 1;
+                this.x = this.range.getMinX();
+                this.z += 1;
+                if (this.z > this.range.getMaxZ()) {
+                    this.z = this.range.getMinZ();
+                    this.y += 1;
+                    if (this.y > this.range.getMaxY()) 
+                        hasMoreBlocks = false; 
                 }
             }
 

--- a/src/main/java/com/infinityraider/agricraft/reference/AgriCraftConfig.java
+++ b/src/main/java/com/infinityraider/agricraft/reference/AgriCraftConfig.java
@@ -50,7 +50,7 @@ public class AgriCraftConfig {
     @AgriConfigurable(category = AgriConfigCategory.IRRIGATION, key = "Sprinkler growth chance", min = "0", max = "100", comment = "Every x seconds each plant in sprinkler range has this chance to growth tick")
     public static int sprinklerGrowthChance = 20;
     @AgriConfigurable(category = AgriConfigCategory.IRRIGATION, key = "Sprinkler water usage", min = "0", max = "10000", comment = "Water usage of the sprinkler in mB per second")
-    public static int sprinklerRatePerSecond = 10;
+    public static int sprinklerRatePerSecond = 20; // Note: this was 10, but integer division by 20 results in zero usage per update.
     public static int sprinklerRatePerHalfSecond = 5;
     public static float sprinklerGrowthChancePercent = 0.1f;
     public static int sprinklerGrowthIntervalTicks = 100;

--- a/src/main/java/com/infinityraider/agricraft/tiles/irrigation/TileEntityChannel.java
+++ b/src/main/java/com/infinityraider/agricraft/tiles/irrigation/TileEntityChannel.java
@@ -208,7 +208,7 @@ public class TileEntityChannel extends TileEntityCustomWood implements ITickable
                 }
             }
             // Handle Sprinklers
-            TileEntitySprinkler spr = WorldHelper.getTile(worldObj, this.pos.add(0, 1, 0), TileEntitySprinkler.class).orElse(null);
+            TileEntitySprinkler spr = WorldHelper.getTile(worldObj, this.pos.add(0, -1, 0), TileEntitySprinkler.class).orElse(null);
             if (spr != null) {
                 updatedLevel = spr.acceptFluid(1000, updatedLevel, true);
             }

--- a/src/main/java/com/infinityraider/agricraft/tiles/irrigation/TileEntitySprinkler.java
+++ b/src/main/java/com/infinityraider/agricraft/tiles/irrigation/TileEntitySprinkler.java
@@ -38,10 +38,10 @@ public class TileEntitySprinkler extends TileEntityBase implements ITickable, II
     private float angle = 0.0F;
     private boolean active = false;
 
-    private final BlockRange range;
+    //private final BlockRange range;
 
     public TileEntitySprinkler() {
-        this.range = new BlockRange(this.getPos().add(-RADIUS, -1, -RADIUS), this.getPos().add(RADIUS, -HEIGHT, RADIUS));
+        //this.range = new BlockRange(this.getPos().add(-RADIUS, -1, -RADIUS), this.getPos().add(RADIUS, -HEIGHT, RADIUS));
     }
 
     /**
@@ -88,7 +88,8 @@ public class TileEntitySprinkler extends TileEntityBase implements ITickable, II
         if (!worldObj.isRemote && this.isActive()) {
             this.counter = (counter + 1) % AgriCraftConfig.sprinklerGrowthIntervalTicks;
             this.buffer -= 10;
-            this.range.stream().forEach(p -> this.irrigate(p, false));
+            BlockRange range = new BlockRange(this.getPos().add(-RADIUS, -1, -RADIUS), this.getPos().add(RADIUS, -HEIGHT, RADIUS));
+            range.stream().forEach(p -> this.irrigate(p, false));
         } else if (this.active) {
             this.renderLiquidSpray();
         }

--- a/src/main/java/com/infinityraider/agricraft/tiles/irrigation/TileEntitySprinkler.java
+++ b/src/main/java/com/infinityraider/agricraft/tiles/irrigation/TileEntitySprinkler.java
@@ -41,7 +41,7 @@ public class TileEntitySprinkler extends TileEntityBase implements ITickable, II
     private final BlockRange range;
 
     public TileEntitySprinkler() {
-        this.range = new BlockRange(this.getPos().add(-RADIUS, 1, -RADIUS), this.getPos().add(RADIUS, HEIGHT, RADIUS));
+        this.range = new BlockRange(this.getPos().add(-RADIUS, -1, -RADIUS), this.getPos().add(RADIUS, -HEIGHT, RADIUS));
     }
 
     /**


### PR DESCRIPTION
A collection of fixes that return basic functionality to sprinklers. Hopefully helps with #862. The commits should be broken up such that a subset of them can still be used even if not all the commits meet the quality and style standards. At the very least, I've tested my patches at every step, and I've stepped through the debugger to confirm both the bugs and the fixes. 

### Summary of changes: 
* The TileEntitySprinkler uses a BlockRange to represent its area of effect. There were a couple problems though: the area was being created above the BlockPosition (not below), and it was created while `pos = BlockPos.ORIGIN`. So all the sprinklers in the world were magically irrigating the same part of bedrock. 
  * I flipped the offset, and I moved the `range` creation to the update method, since the game already calculates a lot of BlockPositions. 
* BlockRangeIterator itself had a logic typo that prevented the full volume from being irrigated. If you look at [this](https://github.com/AgriCraft/AgriCraft/commit/4911415b93db77228606f6ba480aa3b4f5bb9e84#diff-2589ee730ff7f2a571892550a82f190e) commit, you can see the earlier/original full iteration. This was something I particularly checked in the debugger to be sure it really was happening. 
  * I corrected the counters in the loops, and also tidied up the flow. 
* The water channels were looking for sprinklers above, instead of below them. Plus the sprinklers were checking the buffer of the channel, instead of their own. 
  * Flipped the offset for the channels, and replaced the sprinkler's water check. 
* Lastly several of the variables, namely water usage rate, growth rate, and growth chance, were using values not accessible from the config menu. This made them hard to debug. 
  * I exchanged the variables used back for now, so that the sprinklers are easier to test. 

### Quirks and things that still need to be done: 
* The sprinklers irrigate all 245 blocks in the cuboid every time, even if some are buried underground! Oops. So that needs to be replaced with something more realistic and efficient. But since the unrealistic behavior has been around for a while (see this [2b3a5d6] example from 2.5 years ago), I figured fixing that version first would be okay. 
* The rates are using integer math for now, and so the configs aren't as precise as they claim to be. 

### Reference photos: 
* In the first photo, you can see that the farmland is being irrigated in a 7x5x7 cuboid centered below the sprinkler. The tilled earth is dry on the same y-level as the sprinkler block, and also six or more y-levels below. 
![agricraft sprinkler patch demo](https://cloud.githubusercontent.com/assets/28678248/26625565/7bc0b3ec-45c2-11e7-991c-099a0c6e4988.png)
* Secondly, after some more tweaking, I got the growth update chance and frequency to respond to the in-game config menu, and so it's possible to crank up the rate to confirm that the effect is also applied. And again, the wheat on the same y-level as the sprinkler is left alone. 
![agricraft sprinkler patch demo2](https://cloud.githubusercontent.com/assets/28678248/26625564/7bba7798-45c2-11e7-9e85-5925c8f467e8.png)

### StackTrace and Code Snippet: 

```java
"Client thread@1" prio=5 tid=0x1 nid=NA runnable
  java.lang.Thread.State: RUNNABLE
	  at com.infinityraider.agricraft.tiles.irrigation.TileEntitySprinkler.<init>(TileEntitySprinkler.java:43)
PROBLEM   at com.infinityraider.agricraft.blocks.irrigation.BlockSprinkler.createNewTileEntity(BlockSprinkler.java:64)
HERE      at com.infinityraider.agricraft.blocks.irrigation.BlockSprinkler.createNewTileEntity(BlockSprinkler.java:43)
 |        at net.minecraft.block.Block.createTileEntity(Block.java:1417)
 +-->     at net.minecraft.world.chunk.Chunk.setBlockState(Chunk.java:669)
	  at net.minecraft.world.World.setBlockState(World.java:388)
	  at net.minecraft.item.ItemBlock.placeBlockAt(ItemBlock.java:184)
	  at net.minecraft.item.ItemBlock.onItemUse(ItemBlock.java:60)
	  at net.minecraft.item.ItemStack.onItemUse(ItemStack.java:159)
	  at net.minecraft.client.multiplayer.PlayerControllerMP.processRightClickBlock(PlayerControllerMP.java:486)
	  at net.minecraft.client.Minecraft.rightClickMouse(Minecraft.java:1603)
	  at net.minecraft.client.Minecraft.processKeyBinds(Minecraft.java:2281)
	  at net.minecraft.client.Minecraft.runTickKeyboard(Minecraft.java:2058)
	  at net.minecraft.client.Minecraft.runTick(Minecraft.java:1846)
	  at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1118)
	  at net.minecraft.client.Minecraft.run(Minecraft.java:406)
	  at net.minecraft.client.main.Main.main(Main.java:118)
	  at sun.reflect.NativeMethodAccessorImpl.invoke0(NativeMethodAccessorImpl.java:-1)
	  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	  at java.lang.reflect.Method.invoke(Method.java:498)
	  at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	  at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	  at sun.reflect.NativeMethodAccessorImpl.invoke0(NativeMethodAccessorImpl.java:-1)
	  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	  at java.lang.reflect.Method.invoke(Method.java:498)
	  at net.minecraftforge.gradle.GradleStartCommon.launch(GradleStartCommon.java:97)
	  at GradleStart.main(GradleStart.java:26)


Chunk.java: 
    tileentity1 = block.createTileEntity(this.worldObj, state); // No position information passed. 
    this.worldObj.setTileEntity(pos, tileentity1);              // Position added afterwards. 
```

#### Epilogue: 

Please reply with any thoughts, observations, and feedback! 

I do realize that sprinklers are a low priority feature, so I don't assume these commits will be useful or used. But once I spotted some potential bugs that would be easy to fix, I decided it would be worth trying to debug them. 