### PR TITLE
Fix IllegalArgumentException in AgriHarvestProduct

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/impl/v1/AgriHarvestProduct.java
+++ b/src/main/java/com/infinityraider/agricraft/impl/v1/AgriHarvestProduct.java
@@ -64,7 +64,7 @@ public final class AgriHarvestProduct implements IAgriHarvestProduct {
 
     @Override
     public int getAmount(Random rand) {
-        return this.getMinAmount() + rand.nextInt(this.maxAmount - this.minAmount);
+        return this.getMinAmount() + rand.nextInt(1 + this.maxAmount - this.minAmount);
     }
 
     @Override


### PR DESCRIPTION
The method `Random.nextInt(int bound)` needs bound to be positive,
namely non-zero. Any plant's products that had `min == max` would
therefore cause exceptions. Since the bound is exclusive anyhow, this
commit adds 1 to the bound.

An extra side effect of this bug is that the exception would interrupt
the `onHarvest` event, and so the growth stage would not get reset. You
could get seeds repeatedly until the chance failed and the plant didn't
try to produce any products.