### PR TITLE
Rename IAgriCrop methods with AbstractMethodErrors

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/api/v1/crop/IAgriCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/api/v1/crop/IAgriCrop.java
@@ -24,17 +24,21 @@ public interface IAgriCrop extends IAgriSeedProvider, IAgriSeedAcceptor, IAgriFe
 
     /**
      * Retrieves the location of the crop instance.
+     * Implementors can just call getPos() if possible. Renamed because of ForgeGradle obfuscation bug.
+     * https://github.com/MinecraftForge/ForgeGradle/issues/205
      *
      * @return the crop's position.
      */
-    BlockPos getPos();
+    BlockPos getPosDeobf();
 
     /**
      * Retrieves the world that the crop is in.
+     * Implementors can just call getWorld() if possible. Renamed because of ForgeGradle obfuscation bug.
+     * https://github.com/MinecraftForge/ForgeGradle/issues/205
      *
      * @return The world in which the crop is located.
      */
-    World getWorld();
+    World getWorldDeobf();
 
     /**
      * @return The growth stage of the crop, between 0 and 7 (both inclusive).

--- a/src/main/java/com/infinityraider/agricraft/api/v1/crop/IAgriCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/api/v1/crop/IAgriCrop.java
@@ -29,7 +29,7 @@ public interface IAgriCrop extends IAgriSeedProvider, IAgriSeedAcceptor, IAgriFe
      *
      * @return the crop's position.
      */
-    BlockPos getPosDeobf();
+    BlockPos getCropPos();
 
     /**
      * Retrieves the world that the crop is in.
@@ -38,7 +38,7 @@ public interface IAgriCrop extends IAgriSeedProvider, IAgriSeedAcceptor, IAgriFe
      *
      * @return The world in which the crop is located.
      */
-    World getWorldDeobf();
+    World getCropWorld();
 
     /**
      * @return The growth stage of the crop, between 0 and 7 (both inclusive).

--- a/src/main/java/com/infinityraider/agricraft/farming/mutation/MutateStrategy.java
+++ b/src/main/java/com/infinityraider/agricraft/farming/mutation/MutateStrategy.java
@@ -29,7 +29,7 @@ public class MutateStrategy implements IAgriCrossStrategy {
         Objects.requireNonNull(rand, "The random passed to a mutation strategy should not be null!");
 
         // Fetch all neighboring crop instances.
-        final List<IAgriCrop> neighbors = WorldHelper.getTileNeighbors(crop.getWorld(), crop.getPos(), IAgriCrop.class);
+        final List<IAgriCrop> neighbors = WorldHelper.getTileNeighbors(crop.getWorldDeobf(), crop.getPosDeobf(), IAgriCrop.class);
 
         // Determine all possible parents.
         final List<IAgriPlant> parents = neighbors.stream()

--- a/src/main/java/com/infinityraider/agricraft/farming/mutation/MutateStrategy.java
+++ b/src/main/java/com/infinityraider/agricraft/farming/mutation/MutateStrategy.java
@@ -29,7 +29,7 @@ public class MutateStrategy implements IAgriCrossStrategy {
         Objects.requireNonNull(rand, "The random passed to a mutation strategy should not be null!");
 
         // Fetch all neighboring crop instances.
-        final List<IAgriCrop> neighbors = WorldHelper.getTileNeighbors(crop.getWorldDeobf(), crop.getPosDeobf(), IAgriCrop.class);
+        final List<IAgriCrop> neighbors = WorldHelper.getTileNeighbors(crop.getCropWorld(), crop.getCropPos(), IAgriCrop.class);
 
         // Determine all possible parents.
         final List<IAgriPlant> parents = neighbors.stream()

--- a/src/main/java/com/infinityraider/agricraft/farming/mutation/SpreadStrategy.java
+++ b/src/main/java/com/infinityraider/agricraft/farming/mutation/SpreadStrategy.java
@@ -24,7 +24,7 @@ public class SpreadStrategy implements IAgriCrossStrategy {
 
     @Override
     public Optional<AgriSeed> executeStrategy(IAgriCrop crop, Random rand) {
-        List<IAgriCrop> matureNeighbours = WorldHelper.getTileNeighbors(crop.getWorldDeobf(), crop.getPosDeobf(), IAgriCrop.class);
+        List<IAgriCrop> matureNeighbours = WorldHelper.getTileNeighbors(crop.getCropWorld(), crop.getCropPos(), IAgriCrop.class);
         matureNeighbours.removeIf(c -> !c.isMature());
         if (!matureNeighbours.isEmpty()) {
             int index = rand.nextInt(matureNeighbours.size());

--- a/src/main/java/com/infinityraider/agricraft/farming/mutation/SpreadStrategy.java
+++ b/src/main/java/com/infinityraider/agricraft/farming/mutation/SpreadStrategy.java
@@ -24,7 +24,7 @@ public class SpreadStrategy implements IAgriCrossStrategy {
 
     @Override
     public Optional<AgriSeed> executeStrategy(IAgriCrop crop, Random rand) {
-        List<IAgriCrop> matureNeighbours = WorldHelper.getTileNeighbors(crop.getWorld(), crop.getPos(), IAgriCrop.class);
+        List<IAgriCrop> matureNeighbours = WorldHelper.getTileNeighbors(crop.getWorldDeobf(), crop.getPosDeobf(), IAgriCrop.class);
         matureNeighbours.removeIf(c -> !c.isMature());
         if (!matureNeighbours.isEmpty()) {
             int index = rand.nextInt(matureNeighbours.size());

--- a/src/main/java/com/infinityraider/agricraft/tiles/TileEntityCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/tiles/TileEntityCrop.java
@@ -31,6 +31,8 @@ import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -196,6 +198,23 @@ public class TileEntityCrop extends TileEntityBase implements IAgriCrop, IDebugg
 
     // =========================================================================
     // ISeedProvider Methods
+    // </editor-fold>
+    // =========================================================================
+    // =========================================================================
+    // IAgriCrop Methods
+    // <editor-fold>
+    // =========================================================================
+
+    public BlockPos getPosDeobf() {
+        return this.getPos();
+    }
+
+    public World getWorldDeobf() {
+        return this.getWorld();
+    }
+
+    // =========================================================================
+    // IAgriCrop Methods
     // </editor-fold>
     // =========================================================================
     // =========================================================================

--- a/src/main/java/com/infinityraider/agricraft/tiles/TileEntityCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/tiles/TileEntityCrop.java
@@ -205,11 +205,11 @@ public class TileEntityCrop extends TileEntityBase implements IAgriCrop, IDebugg
     // <editor-fold>
     // =========================================================================
 
-    public BlockPos getPosDeobf() {
+    public BlockPos getCropPos() {
         return this.getPos();
     }
 
-    public World getWorldDeobf() {
+    public World getCropWorld() {
         return this.getWorld();
     }
 


### PR DESCRIPTION
Demonstration album: http://imgur.com/a/MvBJ6

For the IAgriCrop interface, this renames the getPos and getWorld
methods so as to not match the methods inherited from TileEntity.
The only uses so far were in the mutation strategies. And the newly
named methods just call the original named methods via 'this'.

This workaround is for a re-obfuscation bug in Special Source, a
program that ForgeGradle depends on.

https://github.com/MinecraftForge/ForgeGradle/issues/205
https://github.com/md-5/SpecialSource/issues/12