### PR TITLE
Fixed Mutations

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/farming/mutation/MutateStrategy.java
+++ b/src/main/java/com/infinityraider/agricraft/farming/mutation/MutateStrategy.java
@@ -79,7 +79,7 @@ public class MutateStrategy implements IAgriCrossStrategy {
         }
 
         // Calculate the stat associated with the new plant.
-        Optional<IAgriStat> stat = AgriApi.getStatCalculatorRegistry().valueOf(mutation).map(c -> c.calculateMutationStats(mutation, neighbors));
+        Optional<IAgriStat> stat = AgriApi.getStatCalculatorRegistry().valueOf(mutation.getChild()).map(c -> c.calculateMutationStats(mutation, neighbors));
 
         // Return the mutation result.
         return stat


### PR DESCRIPTION
Hi guys,

just stumbled on this bug, while trying to get my Sugarcane seed.

To get the stats of the mutation, the StatCalculatorRegistry is asked
with an IAgriMutation object. But the default StatCalculatorRegistries
only handle the IAgriPlant interface. Therefore the code fails to
calculate the stats and no mutation will occur.