### PR TITLE
Fix spread chance inequality

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/tiles/TileEntityCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/tiles/TileEntityCrop.java
@@ -353,7 +353,7 @@ public class TileEntityCrop extends TileEntityBase implements IAgriCrop, IDebugg
         final IAgriPlant plant = seed.getPlant();
 
         // If don't roll a spread event, abort.
-        if (plant.getSpreadChance() <= this.getRandom().nextDouble()) {
+        if (plant.getSpreadChance() > this.getRandom().nextDouble()) {
             for (IAgriCrop crop : WorldHelper.getTileNeighbors(worldObj, pos, IAgriCrop.class)) {
                 final AgriSeed other = crop.getSeed();
                 if (other == null) {


### PR DESCRIPTION
This flips the inequality from <= to >, so that larger values for spread
chance allow plants to spread more frequently. The "not equal" detail is
important, because nextDouble can be 0.0 (lower bound is inclusive).
Otherwise, a spread chance of 0.0 could still succeed.