### PR TITLE
Fix plant products to be in min,max range

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/core/JsonPlant.java
+++ b/src/main/java/com/infinityraider/agricraft/core/JsonPlant.java
@@ -158,7 +158,7 @@ public class JsonPlant implements IAgriPlant {
     @Override
     public void getHarvestProducts(Consumer<ItemStack> products, IAgriCrop crop, IAgriStat stat, Random rand) {
         this.plant.getProducts().getRandom(rand).stream()
-                .map(p -> p.toStack(FuzzyStack.class))
+                .map(p -> p.toStack(FuzzyStack.class, rand))
                 .filter(Optional::isPresent)
                 .map(p -> p.get().toStack())
                 .forEach(products);


### PR DESCRIPTION
This changes which toStack method gets called by getHarvestProducts.
When the Random parameter was missing, AgriStack.toStack(Class) was
being called on the parent, and not AgriProduct.toStack(Class, Random).
The harvest amount randomization from min to max occurs in the latter.