### PR TITLE
Prevent vanilla bonemeal effect on empty crops

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/blocks/BlockCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/blocks/BlockCrop.java
@@ -132,8 +132,10 @@ public class BlockCrop extends BlockTileCustomRenderedBase<TileEntityCrop> imple
 
         // Step 5. If the held item is a type of fertilizer, apply it.
         if (AgriApi.getFertilizerRegistry().hasAdapter(heldItem)) {
-            Optional<IAgriFertilizer> fert = AgriApi.getFertilizerRegistry().valueOf(heldItem);
-            return fert.isPresent() && fert.get().applyFertilizer(player, world, pos, crop, heldItem, crop.getRandom());
+            AgriApi.getFertilizerRegistry()
+                    .valueOf(heldItem)
+                    .ifPresent(f -> f.applyFertilizer(player, world, pos, crop, heldItem, crop.getRandom()));
+            return true; // Even if it didn't grow or cross, we've still handled this block activation, so return true.
         }
 
         // Step 6. If the held item is crops, attempt to make cross-crops.

--- a/src/main/java/com/infinityraider/agricraft/blocks/BlockCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/blocks/BlockCrop.java
@@ -212,7 +212,7 @@ public class BlockCrop extends BlockTileCustomRenderedBase<TileEntityCrop> imple
      */
     @Override
     public boolean canGrow(World world, BlockPos pos, IBlockState state, boolean isClient) {
-        return this.getCrop(world, pos).map(crop -> !crop.isMature()).orElse(false);
+        return this.getCrop(world, pos).map(crop -> crop.hasSeed() && !crop.isMature()).orElse(false);
     }
 
     /**


### PR DESCRIPTION
This pull request consists of two different fixes, either of which resolves the issue, but both of which I think are worth keeping anyhow. Fixing canGrow will prevent other mods and methods from getting misleading results and wasting resources by directly calling applyBonemeal. And fixing onBlockActivated will prevent similar bugs from arising when fertilizers other than bonemeal were integrated into AgriCraft.