### PR TITLE
Feature(s): Already analyzed seeds update the journal. And analysis progress doesn't get reset by removing the journal.

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/tiles/analyzer/TileEntitySeedAnalyzer.java
+++ b/src/main/java/com/infinityraider/agricraft/tiles/analyzer/TileEntitySeedAnalyzer.java
@@ -288,6 +288,7 @@ public class TileEntitySeedAnalyzer extends TileEntityRotatableBase implements I
                     } else {
                         output = this.specimen.copy();
                         this.specimen = null;
+                        this.progress = 0;
                         this.markForUpdate();
                     }
                 }
@@ -300,7 +301,6 @@ public class TileEntitySeedAnalyzer extends TileEntityRotatableBase implements I
                 }
                 break;
         }
-        this.progress = 0;
         return output;
     }
 


### PR DESCRIPTION
When a specimen or journal is inserted into the analyzer, such that an
analyzed seed is present at the same time as a journal that lacks that
plant, then the plant will be added to the journal. This makes the
behavior more intuitive, and less roundabout. Credit for pointing out
this possibility goes to @Dilnu.