### PR TITLE
Fix calculateStatMeanDivisor invalidParents typo

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/farming/mutation/statcalculator/StatCalculatorBase.java
+++ b/src/main/java/com/infinityraider/agricraft/farming/mutation/statcalculator/StatCalculatorBase.java
@@ -160,7 +160,7 @@ public abstract class StatCalculatorBase implements IAgriStatCalculator, IAgriAd
 
         // Account for invalid parents, if enabled in config.
         if (AgriCraftConfig.otherCropsAffectStatsNegatively) {
-            meanDivisor = meanDivisor + validParents;
+            meanDivisor = meanDivisor + invalidParents;
         }
 
         // Verify that the mean divisor is at least one.


### PR DESCRIPTION
The typo in the otherCropsAffectStatsNegatively code meant that
instead of accounting for any invalid parents, the function would
always return double the number of valid parents. This made it
difficult for stats to increase in that case.

-----
Fixes #977 #1028 #1036 and part of #1055.

I have successfully bred plants (wheat, carrots, beets, pumpkins, etc)
to 10/10/10, see screenshot for an example. Importantly, this was with 
the config for `otherCropsAffectStatsNegatively` enabled, since that 
was part of the bug. For these experiments I had `fertilizerMutation`
set to true, spread strategy at 50%, and the stat calculator set to 
normal. It also took several stacks of bonemeal, but overall less than 
15 minutes to get a plant up to max, starting with 1/1/1 seeds.

![agricraft spread stats](https://user-images.githubusercontent.com/28678248/29611575-fe077ba6-87cb-11e7-9561-1ae39350f084.png)
