### PR TITLE
Block trowels from working on cross-crops

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/items/ItemTrowel.java
+++ b/src/main/java/com/infinityraider/agricraft/items/ItemTrowel.java
@@ -56,7 +56,10 @@ public class ItemTrowel extends ItemBase implements IAgriTrowelItem, IItemWithMo
         if (te instanceof IAgriCrop) {
             IAgriCrop crop = (IAgriCrop) te;
             Optional<AgriSeed> seed = AgriApi.getSeedRegistry().valueOf(stack);
-            if (crop.hasSeed() && !seed.isPresent()) {
+            if (crop.isCrossCrop()) {
+                // Cross-crops cannot hold seeds, so the trowel cannot extract from or insert into them.
+                return EnumActionResult.FAIL;
+            } else if (crop.hasSeed() && !seed.isPresent()) {
                 seed = Optional.ofNullable(crop.getSeed());
                 crop.setSeed(null);
                 if (seed.isPresent()) {


### PR DESCRIPTION
This edit of `ItemTrowel::onItemUse` adds a check for cross-crop status on
the crop. This prevents trowels from inserting seeds into cross-crops.

----
While testing, I noticed that I could use a full trowel on a cross-crop, and
this would set that crop to have that seed, but leave the crop still as a 
cross-crop. It rendered both aspects successfully, but the crop itself was
now in an invalid state. Since it was a cross, the plant would never get to
grow. And a cross-over would overwrite the seed already inside the crop.
Because of the same bug, the trowel could actually remove the seed from
the cross-crop-with-seed.

#### Edit: 
I noticed too late that an unnecessary import got included in the patch.
It's been removed, the commit's been amended, and the pull request is updated.