### PR TITLE
Reset growthstage to zero when plants change

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/api/v1/crop/IAgriCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/api/v1/crop/IAgriCrop.java
@@ -42,11 +42,15 @@ public interface IAgriCrop extends IAgriSeedProvider, IAgriSeedAcceptor, IAgriFe
     int getGrowthStage();
 
     /**
-     * Sets the growth stage for this crop
+     * Sets the growth stage for this crop, normalized to the range of valid values for the plant.
+     * If there is no plant, this will set the stage to zero, and log a warning if the input was non-zero.
+     * If growthStage changes, this will call markForUpdate and return true to inform the caller.
+     * Otherwise this will return false to indicate that growthStage didn't change and didn't do an update.
      *
-     * @param stage the growth stage, between 0 and 7 (both inclusive).
+     * @param stage The new value, from 0 (inclusive) up to the plant's stage amount (exclusive), if this has a plant.
+     * @return true if this changed the value and markForUpdate was called.
      */
-    void setGrowthStage(int stage);
+    boolean setGrowthStage(int stage);
 
     /**
      * @return if this crop is a crosscrop

--- a/src/main/java/com/infinityraider/agricraft/api/v1/seed/IAgriSeedAcceptor.java
+++ b/src/main/java/com/infinityraider/agricraft/api/v1/seed/IAgriSeedAcceptor.java
@@ -20,9 +20,10 @@ public interface IAgriSeedAcceptor {
 
     /**
      * Sets the seed associated with this instance.
+     * Use null to remove the seed from this instance.
      *
      * @param seed the seed to associate with this instance.
-     * @return the seed priorly associated with this instance.
+     * @return true if this changed the value, or false if they were equal already.
      */
     boolean setSeed(@Nullable AgriSeed seed);
 

--- a/src/main/java/com/infinityraider/agricraft/tiles/TileEntityCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/tiles/TileEntityCrop.java
@@ -1,6 +1,7 @@
 package com.infinityraider.agricraft.tiles;
 
 import com.agricraft.agricore.core.AgriCore;
+import com.agricraft.agricore.util.MathHelper;
 import com.infinityraider.agricraft.api.v1.AgriApi;
 import com.infinityraider.agricraft.api.v1.crop.IAgriCrop;
 import com.infinityraider.agricraft.api.v1.fertilizer.IAgriFertilizer;
@@ -188,12 +189,36 @@ public class TileEntityCrop extends TileEntityBase implements IAgriCrop, IDebugg
         return (!this.crossCrop) && (this.seed == null || seed == null);
     }
 
+    /**
+     * This sets the seed for this crop. Using null will remove the seed.
+     * If this call changes the value for seed:
+     * - It will first reset the growth stage back to zero.
+     * - Then it will make sure that markForUpdate gets called, if setGrowthStage didn't do it already.
+     * - And then it will return true.
+     * Otherwise it will return false, indicating there was no change and no update.
+     *
+     * @param seed the seed to associate with this instance.
+     * @return true if this changed the seed and caused an update.
+     */
     @Override
     public boolean setSeed(AgriSeed seed) {
-        final AgriSeed oldSeed = this.seed;
+        // Check if the new value is already equal to the current seed. (I.e. same plant and same stats.)
+        if (seed != null ? seed.equals(this.seed) : this.seed == null) {
+            // No change to make.
+            return false;
+        }
+
+        // Otherwise set the seed to the new value.
         this.seed = seed;
-        this.markForUpdate();
-        return this.seed != oldSeed;
+
+        // Also reset the growth. This happens regardless of if we're adding, removing, or changing a seed.
+        if (!setGrowthStage(0)) {
+            // If setGrowthStage didn't cause an update already, then we make sure we do.
+            this.markForUpdate();
+        }
+
+        // Finally report that a change and an update did occur.
+        return true;
     }
 
     // =========================================================================
@@ -262,28 +287,30 @@ public class TileEntityCrop extends TileEntityBase implements IAgriCrop, IDebugg
     }
 
     @Override
-    public void setGrowthStage(int stage) {
-        // If remote, abort!
+    public boolean setGrowthStage(int stage) {
+        // If remote, abort! No change to report.
         if (this.isRemote()) {
-            return;
+            return false;
         }
 
-        // If no seed, abort!
-        if (!this.hasSeed()) {
-            return;
-        }
-
-        // Bring growth stage into bounds.
-        if (stage < 0) {
+        // Make sure that the new value is valid.
+        if (this.hasSeed()) {
+            // If there is a plant currently, make sure the value is valid.
+            stage = MathHelper.inRange(stage, 0, this.seed.getPlant().getGrowthStages() - 1);
+        } else if (stage != 0) {
+            // If this has no plant, the growth stage should be zero.
+            // And if someone was trying to set it as non-zero, then that's a mistake.
+            AgriCore.getCoreLogger().warn("Can't set a non-zero growth stage when a crop has no seed!");
             stage = 0;
-        } else if (stage >= this.seed.getPlant().getGrowthStages()) {
-            stage = this.seed.getPlant().getGrowthStages() - 1;
         }
 
         // If the new growth stage is different, perform update.
         if (stage != this.growthStage) {
             this.growthStage = stage;
             this.markForUpdate();
+            return true;
+        } else {
+            return false;
         }
     }
 
@@ -441,7 +468,6 @@ public class TileEntityCrop extends TileEntityBase implements IAgriCrop, IDebugg
     public boolean onRaked(@Nullable EntityPlayer player) {
         if (!this.isRemote() && this.canBeRaked()) {
             this.getDrops(stack -> WorldHelper.spawnItemInWorld(this.worldObj, this.pos, stack), false);
-            this.setGrowthStage(0);
             this.setSeed(null);
             return true;
         } else {


### PR DESCRIPTION
## Updated and force pushed
#### Original commit is here: 840c5f78

-----
#### Commit message:
With this edit:
- TileEntityCrop::setGrowthStage can now reset growth even when there's
  no plant. It also makes sure that growthStage always gets set to zero
  in that case, and logs a warning otherwise.
  It now returns a boolean to indicate if there was a change and update.
  Also it uses MathHelper::inRange instead of doing it manually.
- TileEntityCrop::setSeed now checks first if the new seed is equal to
  old, using the AgriSeed::equals method if possible, and returns early.
  It now calls setGrowthStage(0), and wil only call markForUpdate if
  that method didn't already.
- TileEntityCrop::onRaked doesn't have to reset the growth as a result.
- The signature for IAgriCrop::setGrowthStage was changed to match. The
  existing uses are unaffected, since the return value just gets ignored.
- Documentation was added or updated in IAgriCrop, IAgriSeedAcceptor,
  and TileEntityCrop for all these methods, to record the effects,
  expectations, and intentions of the code.

Overall:
This prevents items (such as the trowel) from removing a grown plant
while leaving the growthStage unchanged. A different plant or seed then
could get planted and it would have that non-zero growthStage.
Similarly, it prevents accidents where code might remove the seed before
resetting the growth stage, instead of after. Setting the growth stage
would silently fail in that scenario.
Finally, it reduces the number of calls to markForUpdate by removing
some existing repetition. (E.g. onRaked.)

----
#### Commentary:
While moving plants around using a trowel, I noticed that extracting a
mature plant from a crop and then inserting it to the same crop would
return it to its mature state, but inserting it into a fresh crop produced
a plant with zero growth. Further testing showed that the growth level
could be transferred between plants this way, allowing for all sorts of
mischief. 