### PR TITLE
Fix TileEntityCrop::onHarvest ItemCrop spawning

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/tiles/TileEntityCrop.java
+++ b/src/main/java/com/infinityraider/agricraft/tiles/TileEntityCrop.java
@@ -422,8 +422,10 @@ public class TileEntityCrop extends TileEntityBase implements IAgriCrop, IDebugg
         if (this.isRemote()) {
             return MethodResult.PASS;
         } else if (this.isCrossCrop()) {
-            this.setCrossCrop(false);
-            WorldHelper.spawnItemInWorld(this.worldObj, this.pos, new ItemStack(AgriItems.getInstance().CROPS, 1));
+            if (this.setCrossCrop(false)) {
+                // Only spawn the crop stick if the cross was successfully removed.
+                WorldHelper.spawnItemInWorld(this.worldObj, this.pos, new ItemStack(AgriItems.getInstance().CROPS, 1));
+            }
             return MethodResult.SUCCESS;
         } else if (this.canBeHarvested()) {
             this.getDrops(stack -> WorldHelper.spawnItemInWorld(this.worldObj, this.pos, stack), false);


### PR DESCRIPTION
On the rare occassion that `setCrossCrop(false)` fails, `onHarvest`
should not spawn an ItemCrop anyhow. That would allow the duping of crop
sticks. An example of such a situation is a cross crop that also has a
seed growing on it. Even though that shouldn't happen, the code needs to
watch out for invalid situations like that.

----
#### Screenshot from the #1063 PR, showing the spawning: 
![agricraft itemtrowel and cross crops 3](https://user-images.githubusercontent.com/28678248/29644216-63cd9db4-8842-11e7-9929-49780cb55aae.png)
