### PR TITLE
SpreadStrategy stat calculation uses all neighbors

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/farming/mutation/SpreadStrategy.java
+++ b/src/main/java/com/infinityraider/agricraft/farming/mutation/SpreadStrategy.java
@@ -6,6 +6,9 @@ import com.infinityraider.agricraft.api.v1.mutation.IAgriCrossStrategy;
 import com.infinityraider.agricraft.api.v1.seed.AgriSeed;
 import com.infinityraider.agricraft.reference.AgriCraftConfig;
 import com.infinityraider.infinitylib.utility.WorldHelper;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -23,8 +26,10 @@ public class SpreadStrategy implements IAgriCrossStrategy {
     }
 
     @Override
-    public Optional<AgriSeed> executeStrategy(IAgriCrop crop, Random rand) {
-        List<IAgriCrop> matureNeighbours = WorldHelper.getTileNeighbors(crop.getCropWorld(), crop.getCropPos(), IAgriCrop.class);
+    @Nonnull
+    public Optional<AgriSeed> executeStrategy(@Nonnull IAgriCrop crop, @Nonnull Random rand) {
+        List<IAgriCrop> allNeighbours = WorldHelper.getTileNeighbors(crop.getCropWorld(), crop.getCropPos(), IAgriCrop.class);
+        List<IAgriCrop> matureNeighbours = new ArrayList<>(allNeighbours);
         matureNeighbours.removeIf(c -> !c.isMature());
         if (!matureNeighbours.isEmpty()) {
             int index = rand.nextInt(matureNeighbours.size());
@@ -32,7 +37,7 @@ public class SpreadStrategy implements IAgriCrossStrategy {
             if (seed != null && rand.nextDouble() < seed.getPlant().getSpreadChance()) {
                 return AgriApi.getStatCalculatorRegistry()
                         .valueOf(seed.getPlant())
-                        .map(calc -> calc.calculateSpreadStats(seed.getPlant(), matureNeighbours))
+                        .map(calc -> calc.calculateSpreadStats(seed.getPlant(), allNeighbours))
                         .map(stat -> new AgriSeed(seed.getPlant(), stat));
             }
         }


### PR DESCRIPTION
Copies the list of neighbors before removing the immature ones, so that
the full list can be passed to calculateSpreadStats. This way the
otherCropsAffectStatsNegatively config option will have the full effect.
Immature plants are counted as invalid parents in the calculations.

This commit also adds the @Nonnull annotations to the executeStrategy
method, in order to please the IDE.

---

### With this patch, spreading from a 10/10/10 plant
#### otherCropsAffectStatsNegatively = true
![agricraft spreadstrategy neighbors 1](https://user-images.githubusercontent.com/28678248/29990516-76ac46a2-8f49-11e7-91bd-2fb9c2247707.png)
Note that `floor(10/4) = 2`. And since I (accidently) had "Single spread stat increase"=true, they had a chance to increase by 1 point. Thus the result of 2/3/3.
#### otherCropsAffectStatsNegatively = false
![agricraft spreadstrategy neighbors 2](https://user-images.githubusercontent.com/28678248/29990519-7ada7848-8f49-11e7-8e72-9b34ab46a6c9.png)

### Reference: [[StackOverflow]](https://stackoverflow.com/questions/54909/how-do-i-clone-a-generic-list-in-java) for different methods of making a shallow copy of a List.