### PR TITLE
Fix Agriseed stat returns

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/api/v1/seed/AgriSeed.java
+++ b/src/main/java/com/infinityraider/agricraft/api/v1/seed/AgriSeed.java
@@ -68,7 +68,9 @@ public final class AgriSeed {
         this.stat.writeToNBT(tag);
 
         // Return a new stack.
-        return new ItemStack(stack.getItem(), size, stack.getMetadata(), tag);
+        ItemStack toReturn = new ItemStack(stack.getItem(), size, stack.getMetadata());
+toReturn.setTagCompound(tag);
+return toReturn;
     }
 
     @Override


### PR DESCRIPTION
Seeds should now return the proper stats, instead of a 1/1/1 seed.