### PR TITLE
Fix for issue #1113

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/blocks/irrigation/BlockSprinkler.java
+++ b/src/main/java/com/infinityraider/agricraft/blocks/irrigation/BlockSprinkler.java
@@ -100,6 +100,15 @@ public class BlockSprinkler extends BlockTileCustomRenderedBase<TileEntitySprink
     }
 
     @Override
+    public void onBlockPlacedBy(World world, BlockPos pos, IBlockState state, EntityLivingBase placer, ItemStack stack) {
+        // Call supermethod.
+        super.onBlockPlacedBy(world, pos, state, placer, stack);
+        // Update tile above.
+        WorldHelper.getTile(world, pos.add(0, 1, 0), IAgriConnectable.class)
+                .ifPresent(IAgriConnectable::refreshConnections);
+    }
+
+    @Override
     public void observedNeighborChange(IBlockState state, World world, BlockPos pos, Block changedBlock, BlockPos changedBlockPos) {
         if (!this.canBlockStay(world, pos)) {
             this.dropBlockAsItem(world, pos, state, 0);

--- a/src/main/java/com/infinityraider/agricraft/blocks/irrigation/BlockSprinkler.java
+++ b/src/main/java/com/infinityraider/agricraft/blocks/irrigation/BlockSprinkler.java
@@ -1,5 +1,6 @@
 package com.infinityraider.agricraft.blocks.irrigation;
 
+import com.infinityraider.agricraft.api.v1.misc.IAgriConnectable;
 import com.infinityraider.agricraft.api.v1.misc.IAgriFluidComponent;
 import com.infinityraider.agricraft.items.blocks.ItemBlockAgricraft;
 import com.infinityraider.agricraft.items.tabs.AgriTabs;
@@ -22,6 +23,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;


### PR DESCRIPTION
The sprinkler not working is due to the above channel not refreshing connections when the sprinkler is placed on it. If a channel is placed next to the one on top of sprinkler this will cause a connections refresh and the sprinkler will start working. This change makes the sprinkler update the above channel as it is placed, making it work as intended.