### PR TITLE
Added support for Industrial Foregoing to be able to harvest crop sticks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,22 @@ repositories {
         name "ActuallyAdditions"
         url "https://maven.chaosfield.at/"
     }
+    maven {
+        name "Industrial Foregoing"
+        url "http://dyonovan.com/maven2/"
+    }
+    maven {
+        name "Tesla Core Lib"
+        url "http://maven.epoxide.xyz/"
+    }
+    maven {
+        name "cofh"
+        url "http://maven.covers1624.net/"
+    }
+    maven {
+        name "forgelin"
+        url  "http://maven.shadowfacts.net/"
+    }
 }
 
 // List Deps.
@@ -62,6 +78,7 @@ dependencies {
     deobfCompile "de.ellpeck.actuallyadditions:ActuallyAdditions:1.12.1-r121"
     deobfCompile "li.cil.oc:OpenComputers:MC1.12.2-1.7.1.63"
     deobfCompile ("mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.19-11") { transitive = false }
+    deobfCompile "com.buuz135.industrial.IndustrialForegoing:industrialforegoing:1.12.2-1.9.0-236"
 }
 
 // Add AgriPlants

--- a/mod.properties
+++ b/mod.properties
@@ -11,12 +11,12 @@ package = com.infinityraider.agricraft
 # Version
 version_major = 2
 version_minor = 12
-version_patch = 0-1.12.0-a4
+version_patch = 0-1.12.0-a5
 
 # Core
 version_minecraft = 1.12.2
 version_mappings = snapshot_20180225
-version_forge = 14.23.2.2618
+version_forge = 14.23.3.2673
 version_java = 1.8
 
 # InfinityLib

--- a/src/main/java/com/infinityraider/agricraft/compat/industrialforegoing/CropsPlantRecollectable.java
+++ b/src/main/java/com/infinityraider/agricraft/compat/industrialforegoing/CropsPlantRecollectable.java
@@ -1,0 +1,56 @@
+package com.infinityraider.agricraft.compat.industrialforegoing;
+
+import com.buuz135.industrial.api.plant.PlantRecollectable;
+import com.infinityraider.agricraft.blocks.BlockCrop;
+import com.infinityraider.agricraft.tiles.TileEntityCrop;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CropsPlantRecollectable extends PlantRecollectable
+{
+    public CropsPlantRecollectable()
+    {
+        super("blockagricraftcrops");
+    }
+
+    @Override
+    public boolean canBeHarvested(World world, BlockPos pos, IBlockState blockState)
+    {
+        return blockState.getBlock() instanceof BlockCrop && ((BlockCrop)blockState.getBlock()).isMature(world, pos);
+    }
+
+    @Override
+    public List<ItemStack> doHarvestOperation(World world, BlockPos pos, IBlockState blockState)
+    {
+        NonNullList<ItemStack> stacks = NonNullList.create();
+
+        TileEntity te = world.getTileEntity(pos);
+        if (te instanceof TileEntityCrop)
+        {
+            TileEntityCrop cropTile = (TileEntityCrop)te;
+            if (cropTile.isMature())
+                cropTile.onHarvest(stacks::add, null);
+        }
+
+        return stacks;
+    }
+
+    @Override
+    public boolean shouldCheckNextPlant(World world, BlockPos pos, IBlockState blockState)
+    {
+        return true;
+    }
+
+    @Override
+    public List<String> getRecollectablesNames()
+    {
+        return Arrays.asList("item.agricraft:crop_sticks.compat.name");
+    }
+}

--- a/src/main/java/com/infinityraider/agricraft/core/CoreHandler.java
+++ b/src/main/java/com/infinityraider/agricraft/core/CoreHandler.java
@@ -7,10 +7,12 @@ import com.agricraft.agricore.plant.AgriMutation;
 import com.agricraft.agricore.plant.AgriPlant;
 import com.agricraft.agricore.plant.AgriSoil;
 import com.agricraft.agricore.util.ResourceHelper;
+import com.buuz135.industrial.api.plant.PlantRecollectable;
 import com.infinityraider.agricraft.api.v1.AgriApi;
 import com.infinityraider.agricraft.api.v1.mutation.IAgriMutation;
 import com.infinityraider.agricraft.api.v1.plant.IAgriPlant;
 import com.infinityraider.agricraft.api.v1.soil.IAgriSoil;
+import com.infinityraider.agricraft.compat.industrialforegoing.CropsPlantRecollectable;
 import com.infinityraider.agricraft.reference.Reference;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -20,8 +22,10 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.registries.IForgeRegistry;
 
 public final class CoreHandler {
 
@@ -82,6 +86,16 @@ public final class CoreHandler {
         initSoils();
         initPlants();
         initMutations();
+
+        // Is Industrial Foregoing registered?
+        IForgeRegistry<PlantRecollectable> registry = GameRegistry.findRegistry(PlantRecollectable.class);
+        if (registry != null)
+        {
+            registry.register(new CropsPlantRecollectable());
+            AgriCore.getLogger("agricraft").info("Registered Industral Foregoing PlantRecollectable!");
+        }
+        else
+            AgriCore.getLogger("agricraft").info("Industrial Foregoing registry not found, did not register PlantRecollectable.");
     }
 
     public static void loadJsons() {

--- a/src/main/resources/assets/agricraft/lang/en_US.lang
+++ b/src/main/resources/assets/agricraft/lang/en_US.lang
@@ -135,6 +135,7 @@ agricraft_description.method.needsBaseBlock=Returns if the crop crop at the spec
 // ========================================
 agricraft_arg.direction=direction
 agricraft_arg.direction.optional=(optional) direction
+item.agricraft:crop_sticks.compat.name= - Crop Sticks §o(AgriCraft)
 
 // ========================================
 // NEI GUI


### PR DESCRIPTION
MFR hasn't been updated for 1.12 as far as I can tell and has been replaced by Industrial Foregoing.  

Currently, the Industrial Foregoing machines can't harvest crops in AgriCraft crop sticks (they just leave the drops lying on the ground). This PR adds support to AgriCraft to allow Industrial Foregoing to harvest crops growing in AgriCraft crop sticks (tested on vanilla, Botania, and Pam's HarvestCraft crops).