### PR TITLE
Update AA dependency & fix subsequent error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     compile 'com.google.guava:guava:24.0-jre'
     deobfCompile "mezz.jei:jei_1.12.2:4.8.5.140"
     // Have to disable transitive deps on this one since stupid stuff is going on...
-    deobfCompile "de.ellpeck.actuallyadditions:ActuallyAdditions:1.12.1-r121"
+    deobfCompile "de.ellpeck.actuallyadditions:ActuallyAdditions:1.12.2-r136"
     deobfCompile "li.cil.oc:OpenComputers:MC1.12.2-1.7.1.63"
     deobfCompile ("mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.19-11") { transitive = false }
 }

--- a/src/main/java/com/infinityraider/agricraft/compat/actuallyadditions/AgriCraftFarmerBehavior.java
+++ b/src/main/java/com/infinityraider/agricraft/compat/actuallyadditions/AgriCraftFarmerBehavior.java
@@ -13,12 +13,13 @@ import com.infinityraider.infinitylib.utility.WorldHelper;
 import de.ellpeck.actuallyadditions.api.farmer.FarmerResult;
 import de.ellpeck.actuallyadditions.api.farmer.IFarmerBehavior;
 import de.ellpeck.actuallyadditions.api.internal.IFarmer;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 /**
  *
@@ -61,7 +62,7 @@ public class AgriCraftFarmerBehavior implements IFarmerBehavior {
             final MethodResult result = agriCrop.get().onHarvest(products::add, null);
             if (result == MethodResult.SUCCESS) {
                 farmer.extractEnergy(ActuallyAdditionsPlugin.ENERGY_COST);
-                farmer.addToOutputInventory(products, true);
+                farmer.addToOutput(products);
                 return FarmerResult.SUCCESS;
             }
         }


### PR DESCRIPTION
Updated Actually Additions, and fixed the subsequent compile error caused by its API change.
This fixes #1148 and #1150. This may require a version bump.