### PR TITLE
Add support for EnderIO Farming Stations to harvest AgriCraft crops

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ repositories {
         url "http://maven.tterrag.com/"
     }
     maven {
+        name "Tterrag Maven2"
+        url "http://maven2.tterrag.com/"
+    }
+    maven {
         name "JEI Maven"
         url "http://dvs1.progwml6.com/files/maven"
     }
@@ -93,6 +97,7 @@ dependencies {
     // *Special* Minecraft Mods
     // Have to disable transitive deps on this one since stupid stuff is going on...
     deobfCompile ("mcjty.theoneprobe:TheOneProbe-1.12:1.12-1.4.19-11") { transitive = false }
+    deobfCompile ("com.enderio:EnderIO:1.12.2-5.0.44:api") { transitive = false }
 }
 
 // Delete Old Plants

--- a/src/main/java/com/infinityraider/agricraft/compat/enderio/AgriFarmerJoe.java
+++ b/src/main/java/com/infinityraider/agricraft/compat/enderio/AgriFarmerJoe.java
@@ -1,0 +1,65 @@
+package com.infinityraider.agricraft.compat.enderio;
+
+import com.infinityraider.agricraft.api.v1.crop.IAgriCrop;
+import com.infinityraider.infinitylib.utility.WorldHelper;
+import crazypants.enderio.api.farm.*;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.math.BlockPos;
+
+public class AgriFarmerJoe extends AbstractFarmerJoe {
+
+    public boolean canPlant(ItemStack stack) {
+        return false;
+    }
+
+    public IFarmerJoe.Result tryPrepareBlock(IFarmer farm, BlockPos pos, IBlockState state) {
+        return IFarmerJoe.Result.NEXT;
+    }
+
+    public boolean canHarvest(IFarmer farm, BlockPos pos, IBlockState state) {
+        return WorldHelper.getTile(farm.getWorld(), pos, IAgriCrop.class)
+                .map(IAgriCrop::canBeHarvested)
+                .orElse(false);
+    }
+
+    public IHarvestResult harvestBlock(IFarmer farm, BlockPos pos, IBlockState state) {
+        if (!canHarvest(farm, pos, state) || !farm.checkAction(FarmingAction.HARVEST, IFarmingTool.Tools.HOE)) {
+            return null;
+        }
+
+        HarvestResult result = new HarvestResult();
+        result.getHarvestedBlocks().add(pos);
+
+        double dropX = pos.getX() + 0.5;
+        double dropY = pos.getY() + 0.5;
+        double dropZ = pos.getZ() + 0.5;
+
+        WorldHelper.getTile(farm.getWorld(), pos, IAgriCrop.class)
+                .ifPresent(tile -> {
+                    tile.onHarvest(stack -> {
+                        result.getDrops().add(new EntityItem(farm.getWorld(), dropX, dropY, dropZ, stack));
+                    }, farm.getFakePlayer());
+                });
+
+        farm.registerAction(FarmingAction.HARVEST, IFarmingTool.Tools.HOE);
+
+        return result;
+    }
+
+    private static class HarvestResult implements IHarvestResult {
+
+        final NonNullList<EntityItem> drops = NonNullList.create();
+        final NonNullList<BlockPos> harvestedBlocks = NonNullList.create();
+
+        public NonNullList<EntityItem> getDrops() {
+            return drops;
+        }
+
+        public NonNullList<BlockPos> getHarvestedBlocks() {
+            return harvestedBlocks;
+        }
+    }
+}

--- a/src/main/java/com/infinityraider/agricraft/compat/enderio/EnderIOPlugin.java
+++ b/src/main/java/com/infinityraider/agricraft/compat/enderio/EnderIOPlugin.java
@@ -1,8 +1,12 @@
 package com.infinityraider.agricraft.compat.enderio;
 
+import com.infinityraider.agricraft.AgriCraft;
 import com.infinityraider.agricraft.api.v1.plugin.AgriPlugin;
 import com.infinityraider.agricraft.api.v1.plugin.IAgriPlugin;
+import crazypants.enderio.api.farm.IFarmerJoe;
+import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 @AgriPlugin
 public class EnderIOPlugin implements IAgriPlugin {
@@ -24,7 +28,15 @@ public class EnderIOPlugin implements IAgriPlugin {
 
     @Override
     public void initPlugin() {
-        // TODO!
+
+    }
+
+    @SubscribeEvent
+    public void registerFarmer(RegistryEvent.Register<IFarmerJoe> event) {
+        AgriFarmerJoe farmer = new AgriFarmerJoe();
+        farmer.setRegistryName(AgriCraft.instance.getModId(), "farmer");
+
+        event.getRegistry().register(farmer);
     }
 
 }


### PR DESCRIPTION
Just as the title says. All this does is add a new "Farmer Joe" to EnderIO's registry which specifically handles AgriCraft's crop block. This doesn't support planting of crops, only picking of pre-planted ones.