### PR TITLE
Forge maven, fixed peripheral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     repositories {
         maven {
             name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            url = "https://maven.minecraftforge.net"
         }
         maven {
             name = "sonatype"

--- a/src/main/java/com/InfinityRaider/AgriCraft/blocks/BlockPeripheral.java
+++ b/src/main/java/com/InfinityRaider/AgriCraft/blocks/BlockPeripheral.java
@@ -1,16 +1,17 @@
 package com.InfinityRaider.AgriCraft.blocks;
 
 import com.InfinityRaider.AgriCraft.AgriCraft;
-import com.InfinityRaider.AgriCraft.container.ContainerSeedAnalyzer;
+import com.InfinityRaider.AgriCraft.container.ContainerPeripheral;
+import com.InfinityRaider.AgriCraft.creativetab.AgriCraftTab;
 import com.InfinityRaider.AgriCraft.handler.GuiHandler;
 import com.InfinityRaider.AgriCraft.init.Blocks;
 import com.InfinityRaider.AgriCraft.network.MessagePeripheralCheckNeighbours;
 import com.InfinityRaider.AgriCraft.network.NetworkWrapperAgriCraft;
+import com.InfinityRaider.AgriCraft.reference.Constants;
 import com.InfinityRaider.AgriCraft.reference.Names;
 import com.InfinityRaider.AgriCraft.renderers.blocks.RenderBlockBase;
 import com.InfinityRaider.AgriCraft.renderers.blocks.RenderPeripheral;
 import com.InfinityRaider.AgriCraft.tileentity.peripheral.TileEntityPeripheral;
-import com.InfinityRaider.AgriCraft.tileentity.TileEntitySeedAnalyzer;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.network.simpleimpl.IMessage;
@@ -33,12 +34,24 @@ import net.minecraft.world.World;
 import java.util.ArrayList;
 
 @Optional.Interface(modid = Names.Mods.computerCraft, iface = "dan200.computercraft.api.peripheral.IPeripheralProvider")
-public class BlockPeripheral extends BlockContainerAgriCraft implements IPeripheralProvider {
+public class BlockPeripheral extends BlockSeedAnalyzer implements IPeripheralProvider {
     @SideOnly(Side.CLIENT)
     private IIcon[] icons;
 
     public BlockPeripheral() {
         super(Material.iron);
+    }
+    
+    @Override
+    protected void setBlockProps() {
+        //set mining statistics
+        this.setHardness(1);
+        this.setResistance(1);
+    }
+    
+    @Override
+    protected int getGuiID() {
+    	return GuiHandler.peripheralID;
     }
 
     @Override
@@ -47,18 +60,7 @@ public class BlockPeripheral extends BlockContainerAgriCraft implements IPeriphe
     }
 
     @Override
-    @SideOnly(Side.CLIENT)
-    public RenderBlockBase getRenderer() {
-        return new RenderPeripheral();
-    }
-
-    @Override
-    protected Class<? extends ItemBlock> getItemBlockClass() {
-        return null;
-    }
-
-    @Override
-    protected String getInternalName() {
+    protected String getTileEntityName() {
         return Names.Objects.peripheral;
     }
 
@@ -73,59 +75,15 @@ public class BlockPeripheral extends BlockContainerAgriCraft implements IPeriphe
     }
 
     @Override
-    protected String getTileEntityName() {
-        return Names.Objects.peripheral;
-    }
-
-    //called when the block is broken
-    @Override
-    public void breakBlock(World world, int x, int y, int z, Block b, int meta) {
-        if(!world.isRemote) {
-            world.removeTileEntity(x, y, z);
-            world.setBlockToAir(x, y, z);
-        }
-    }
-
-    @Override
-    public boolean isMultiBlock() {
-        return false;
-    }
-
-    //override this to delay the removal of the tile entity until after harvestBlock() has been called
-    @Override
-    public boolean removedByPlayer(World world, EntityPlayer player, int x, int y, int z, boolean willHarvest) {
-        return !player.capabilities.isCreativeMode || super.removedByPlayer(world, player, x, y, z, willHarvest);
-    }
-
-    //this gets called when the block is mined
-    @Override
-    public void harvestBlock(World world, EntityPlayer player, int x, int y, int z, int meta) {
-        if(!world.isRemote) {
-            if(!player.capabilities.isCreativeMode) {
-                this.dropBlockAsItem(world, x, y, z, meta, 0);
-            }
-            this.breakBlock(world, x, y, z, world.getBlock(x, y, z), meta);
-        }
-    }
-
-    //open the gui when the block is activated
-    @Override
-    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int side, float fX, float fY, float fZ) {
-        if(player.isSneaking()) {
-            return false;
-        }
-        if(!world.isRemote) {
-            player.openGui(AgriCraft.instance, GuiHandler.peripheralID, world, x, y, z);
-        }
-        return true;
-    }
-
-    @Override
     public void onNeighborBlockChange(World world, int x, int y, int z, Block block) {
         IMessage msg = new MessagePeripheralCheckNeighbours(x, y, z);
         NetworkRegistry.TargetPoint point = new NetworkRegistry.TargetPoint(world.provider.dimensionId, x, y, z, 32);
         NetworkWrapperAgriCraft.wrapper.sendToAllAround(msg, point);
     }
+
+    //rendering stuff
+    @Override
+    public boolean shouldSideBeRendered(IBlockAccess world, int x, int y, int z, int i) {return true;}
 
     @Override
     @SideOnly(Side.CLIENT)
@@ -146,11 +104,13 @@ public class BlockPeripheral extends BlockContainerAgriCraft implements IPeriphe
     }
 
     @Override
-    public boolean isOpaqueCube() {return false;}
+    @SideOnly(Side.CLIENT)
+    public RenderBlockBase getRenderer() {
+        return new RenderPeripheral();
+    }
 
     @Override
-    public boolean renderAsNormalBlock() {return false;}
-
-    @Override
-    public boolean shouldSideBeRendered(IBlockAccess world, int x, int y, int z, int i) {return true;}
+    protected String getInternalName() {
+        return Names.Objects.peripheral;
+    }
 }

--- a/src/main/java/com/InfinityRaider/AgriCraft/blocks/BlockSeedAnalyzer.java
+++ b/src/main/java/com/InfinityRaider/AgriCraft/blocks/BlockSeedAnalyzer.java
@@ -29,11 +29,21 @@ import net.minecraft.world.World;
 import java.util.ArrayList;
 
 public class BlockSeedAnalyzer extends BlockContainerAgriCraft {
-    public BlockSeedAnalyzer() {
-        super(Material.ground);
-        this.setCreativeTab(AgriCraftTab.agriCraftTab);
+	public BlockSeedAnalyzer(Material material) {
+		super(material);
+		
+		this.setCreativeTab(AgriCraftTab.agriCraftTab);
         this.isBlockContainer = true;
         this.setTickRandomly(false);
+
+        this.setBlockProps();
+	}
+	
+    public BlockSeedAnalyzer() {
+    	this(Material.ground);
+    }
+
+    protected void setBlockProps() {
         //set mining statistics
         this.setHardness(1);
         this.setResistance(1);
@@ -45,7 +55,11 @@ public class BlockSeedAnalyzer extends BlockContainerAgriCraft {
         this.maxY = Constants.UNIT * Constants.QUARTER;
         this.minY = 0;
     }
-
+    
+    protected int getGuiID() {
+    	return GuiHandler.seedAnalyzerID;
+    }
+    
     //creates a new tile entity every time a block of this type is placed
     @Override
     public TileEntity createNewTileEntity(World world, int meta) {
@@ -107,7 +121,7 @@ public class BlockSeedAnalyzer extends BlockContainerAgriCraft {
             return false;
         }
         if(!world.isRemote) {
-            player.openGui(AgriCraft.instance, GuiHandler.seedAnalyzerID, world, x, y, z);
+            player.openGui(AgriCraft.instance, getGuiID(), world, x, y, z);
         }
         return true;
     }


### PR DESCRIPTION
Updated link for forge maven.
Changed the peripheral block, it now extends the seed analyzer block.
Also changed the analyzer block class, so that it can be used in this way.

The container class and the entity class of the peripheral block are all extending the seed analyzer classes, but the block class does not. Because of this, it lacks a getDrops method, and does not drop the journal when harvested. It also lacked the hardness property, and on the client you could "destroy" it with one click, but it was not actually destroyed.