### PR TITLE
Update crop_sticks_wood.json

### DIFF
--- a/src/main/resources/data/agricraft/recipes/crop_sticks_wood.json
+++ b/src/main/resources/data/agricraft/recipes/crop_sticks_wood.json
@@ -1,21 +1,15 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "ingredients": [
-    {
-      "tag": "forge:rods/wooden"
-    },
-    {
-      "tag": "forge:rods/wooden"
-    },
-    {
-      "tag": "forge:rods/wooden"
-    },
-    {
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "ss",
+    "ss"
+  ],
+  "key": {
+    "s": {
       "tag": "forge:rods/wooden"
     }
-  ],
-  "result":
-  {
+  },
+  "result": {
     "item": "agricraft:crop_sticks_wood",
     "count": 8
   }


### PR DESCRIPTION
Changed Crop Sticks recipe to be shaped instead of shapeless to reduce conflicts with recipes from other mods (wooden gear recipe for example)