### PR TITLE
Fix multiple mutations with a single output only registering one mutation by changing mutation ID to be based on the file path of the mutation file.

### DIFF
--- a/src/main/java/com/infinityraider/agricraft/impl/v1/JsonHelper.java
+++ b/src/main/java/com/infinityraider/agricraft/impl/v1/JsonHelper.java
@@ -27,7 +27,7 @@ public final class JsonHelper {
         final double chance = mutation.getChance();
 
         // Step III. Determine ID.
-        final String mutationId = mutation.getPath();
+        final String mutationId = getIdFromPath(mutation.getPath());
 
         // Step IV. Determine Child.
         final Optional<IAgriPlant> child = AgriApi.getPlantRegistry().get(mutation.getChild().getId());
@@ -72,6 +72,10 @@ public final class JsonHelper {
                 })
                 // convert the underlying condition into a mutation condition based on the json parameters
                 .map(test -> test.convert(condition.isRequired(), condition.getGuaranteedChance()));
+    }
+
+    private static String getIdFromPath(String path) {
+        return path.replace("/mutations/", ":").replace(".json", "");
     }
 
 }

--- a/src/main/java/com/infinityraider/agricraft/impl/v1/JsonHelper.java
+++ b/src/main/java/com/infinityraider/agricraft/impl/v1/JsonHelper.java
@@ -27,7 +27,7 @@ public final class JsonHelper {
         final double chance = mutation.getChance();
 
         // Step III. Determine ID.
-        final String mutationId = mutation.getChild().getId().replace("_plant", "_mutation");
+        final String mutationId = mutation.getPath();
 
         // Step IV. Determine Child.
         final Optional<IAgriPlant> child = AgriApi.getPlantRegistry().get(mutation.getChild().getId());


### PR DESCRIPTION
As the title would suggest, this fixes a bug where only one mutation could be registered for any given product, by replacing the ID used to store the mutation from a product-based one to a file path-based one.

If needed, a change from path to just filename could still be made, though I doubt the necessity.