### PR TITLE
[1.20.4] EMI plugin: use custom Comparison for seeds

### DIFF
--- a/common/src/main/java/com/agricraft/agricraft/compat/emi/AgriCraftEmiPlugin.java
+++ b/common/src/main/java/com/agricraft/agricraft/compat/emi/AgriCraftEmiPlugin.java
@@ -1,6 +1,7 @@
 package com.agricraft.agricraft.compat.emi;
 
 import com.agricraft.agricraft.api.AgriApi;
+import com.agricraft.agricraft.api.genetic.AgriGenome;
 import com.agricraft.agricraft.common.registry.ModItems;
 import dev.emi.emi.api.EmiInitRegistry;
 import dev.emi.emi.api.EmiPlugin;
@@ -26,6 +27,19 @@ public class AgriCraftEmiPlugin implements EmiPlugin {
 	public static final EmiRecipeCategory PRODUCE_CATEGORY = new EmiRecipeCategory(new ResourceLocation("agricraft", "produce"), WOODEN_CROP_STICK);
 	public static final EmiRecipeCategory CLIPPING_CATEGORY = new EmiRecipeCategory(new ResourceLocation("agricraft", "clipping"), CLIPPER);
 	public static final EmiRecipeCategory REQUIREMENT_CATEGORY = new EmiRecipeCategory(new ResourceLocation("agricraft", "requirement"), FARMLAND);
+
+	public static final Comparison COMPARE_SEEDS = Comparison.compareData(stack -> {
+		var genome = AgriGenome.fromNBT(stack.getNbt());
+		if (genome != null) {
+			return genome.getSpeciesGene().getDominant().trait();
+		} else {
+			return "unknown";
+		}
+	});
+
+	public static Comparison compareSeeds() {
+		return COMPARE_SEEDS;
+	}
 
 	public static <T> ResourceLocation prefixedId(ResourceKey<T> key, String prefix) {
 		return new ResourceLocation("agricraft", "/" + prefix + "/" + key.location().toString().replace(":", "/"));

--- a/common/src/main/java/com/agricraft/agricraft/compat/emi/CropClippingRecipe.java
+++ b/common/src/main/java/com/agricraft/agricraft/compat/emi/CropClippingRecipe.java
@@ -31,7 +31,7 @@ public class CropClippingRecipe implements EmiRecipe {
 
 	public CropClippingRecipe(ResourceLocation id, AgriPlant plant) {
 		this.id = id;
-		input = List.of(EmiStack.of(AgriSeedItem.toStack(plant)).comparison(Comparison.compareNbt()));
+		input = List.of(EmiStack.of(AgriSeedItem.toStack(plant)).comparison(AgriCraftEmiPlugin.compareSeeds()));
 		this.plant = plant;
 		output = new ArrayList<>();
 		plant.getAllPossibleClipProducts(product -> output.add(EmiStack.of(product).comparison(Comparison.compareNbt())));

--- a/common/src/main/java/com/agricraft/agricraft/compat/emi/CropMutationRecipe.java
+++ b/common/src/main/java/com/agricraft/agricraft/compat/emi/CropMutationRecipe.java
@@ -6,7 +6,6 @@ import com.agricraft.agricraft.common.item.AgriSeedItem;
 import dev.emi.emi.api.recipe.EmiRecipe;
 import dev.emi.emi.api.recipe.EmiRecipeCategory;
 import dev.emi.emi.api.render.EmiTexture;
-import dev.emi.emi.api.stack.Comparison;
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;
 import dev.emi.emi.api.widget.WidgetHolder;
@@ -23,9 +22,9 @@ public class CropMutationRecipe implements EmiRecipe {
 
 	public CropMutationRecipe(ResourceLocation id, AgriMutation mutation) {
 		this.id = id;
-		input = List.of(EmiStack.of(AgriSeedItem.toStack(mutation.getParent1().orElse(AgriPlant.NO_PLANT))).comparison(Comparison.compareNbt()),
-				EmiStack.of(AgriSeedItem.toStack(mutation.getParent2().orElse(AgriPlant.NO_PLANT))).comparison(Comparison.compareNbt()));
-		output = List.of(EmiStack.of(AgriSeedItem.toStack(mutation.getChild().orElse(AgriPlant.NO_PLANT))).comparison(Comparison.compareNbt()));
+		input = List.of(EmiStack.of(AgriSeedItem.toStack(mutation.getParent1().orElse(AgriPlant.NO_PLANT))).comparison(AgriCraftEmiPlugin.compareSeeds()),
+				EmiStack.of(AgriSeedItem.toStack(mutation.getParent2().orElse(AgriPlant.NO_PLANT))).comparison(AgriCraftEmiPlugin.compareSeeds()));
+		output = List.of(EmiStack.of(AgriSeedItem.toStack(mutation.getChild().orElse(AgriPlant.NO_PLANT))).comparison(AgriCraftEmiPlugin.compareSeeds()));
 	}
 
 	@Override

--- a/common/src/main/java/com/agricraft/agricraft/compat/emi/CropProduceRecipe.java
+++ b/common/src/main/java/com/agricraft/agricraft/compat/emi/CropProduceRecipe.java
@@ -31,7 +31,7 @@ public class CropProduceRecipe implements EmiRecipe {
 
 	public CropProduceRecipe(ResourceLocation id, AgriPlant plant) {
 		this.id = id;
-		input = List.of(EmiStack.of(AgriSeedItem.toStack(plant)).comparison(Comparison.compareNbt()));
+		input = List.of(EmiStack.of(AgriSeedItem.toStack(plant)).comparison(AgriCraftEmiPlugin.compareSeeds()));
 		this.plant = plant;
 		output = new ArrayList<>();
 		plant.getAllPossibleProducts(product -> output.add(EmiStack.of(product).comparison(Comparison.compareNbt())));

--- a/common/src/main/java/com/agricraft/agricraft/compat/emi/CropRequirementRecipe.java
+++ b/common/src/main/java/com/agricraft/agricraft/compat/emi/CropRequirementRecipe.java
@@ -16,7 +16,6 @@ import com.mojang.math.Axis;
 import dev.emi.emi.api.recipe.EmiRecipe;
 import dev.emi.emi.api.recipe.EmiRecipeCategory;
 import dev.emi.emi.api.render.EmiTexture;
-import dev.emi.emi.api.stack.Comparison;
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;
 import dev.emi.emi.api.widget.ButtonWidget;
@@ -71,7 +70,7 @@ public class CropRequirementRecipe implements EmiRecipe {
 
 	public CropRequirementRecipe(ResourceLocation id, AgriPlant plant) {
 		this.id = id;
-		input = List.of(EmiStack.of(AgriSeedItem.toStack(plant)).comparison(Comparison.compareNbt()));
+		input = List.of(EmiStack.of(AgriSeedItem.toStack(plant)).comparison(AgriCraftEmiPlugin.compareSeeds()));
 		this.plant = plant;
 		output = new ArrayList<>();
 		this.plantId = AgriApi.getPlantId(plant).map(ResourceLocation::toString).orElse("");


### PR DESCRIPTION
Fixes seeds with NBT not having their recipes / usages searchable in EMI