### PR TITLE
[1.20.4] Add plant complexities to DumpRegistriesCommand + Set AgriCraftFabric.cachedServer *before* datapacks are loaded + Fix (Neo)Forge EventBusSubscribers running on wrong side

### DIFF
--- a/common/src/main/java/com/agricraft/agricraft/common/commands/DumpRegistriesCommand.java
+++ b/common/src/main/java/com/agricraft/agricraft/common/commands/DumpRegistriesCommand.java
@@ -55,6 +55,7 @@ public class DumpRegistriesCommand {
 				.then(Commands.literal("soils").executes(commandContext -> DumpRegistriesCommand.dumpSoils()))
 				.then(Commands.literal("mutations").executes(commandContext -> DumpRegistriesCommand.dumpMutations()))
 				.then(Commands.literal("fertilizers").executes(commandContext -> DumpRegistriesCommand.dumpFertilizers()))
+				.then(Commands.literal("complexities").executes(commandContext -> DumpRegistriesCommand.dumpComplexities()))
 				.executes(commandContext -> DumpRegistriesCommand.dumpAllRegistries())
 		);
 
@@ -86,6 +87,11 @@ public class DumpRegistriesCommand {
 	public static int dumpFertilizers() {
 		System.out.println("Fertilizers:");
 		AgriApi.getFertilizerRegistry().ifPresent(registry -> registry.keySet().forEach(System.out::println));
+		return 1;
+	}
+	public static int dumpComplexities() {
+		System.out.println("Complexities:");
+		AgriApi.getPlantRegistry().ifPresent(registry -> registry.keySet().forEach(plant -> System.out.printf("%s | %d%n", plant.toString(), AgriApi.getMutationHandler().complexity(plant.toString()))));
 		return 1;
 	}
 

--- a/fabric/src/main/java/com/agricraft/agricraft/fabric/AgriCraftFabric.java
+++ b/fabric/src/main/java/com/agricraft/agricraft/fabric/AgriCraftFabric.java
@@ -39,7 +39,7 @@ public class AgriCraftFabric implements ModInitializer {
 		DynamicRegistries.registerSynced(AgriApi.AGRISOILS, AgriSoil.CODEC, AgriSoil.CODEC);
 		DynamicRegistries.registerSynced(AgriApi.AGRIMUTATIONS, AgriMutation.CODEC, AgriMutation.CODEC);
 		DynamicRegistries.registerSynced(AgriApi.AGRIFERTILIZERS, AgriFertilizer.CODEC, AgriFertilizer.CODEC);
-		ServerLifecycleEvents.SYNC_DATA_PACK_CONTENTS.register((player, joined) -> cachedServer = player.getServer());
+		ServerLifecycleEvents.SERVER_STARTING.register(server -> cachedServer = server);
 		CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
 			GiveSeedCommand.register(dispatcher, registryAccess);
 			DumpRegistriesCommand.register(dispatcher, registryAccess);

--- a/forge/src/main/java/com/agricraft/agricraft/client/forge/AgriCraftForgeClient.java
+++ b/forge/src/main/java/com/agricraft/agricraft/client/forge/AgriCraftForgeClient.java
@@ -19,6 +19,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.FileToIdConverter;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.client.event.ModelEvent;
 import net.minecraftforge.client.event.RegisterGuiOverlaysEvent;
@@ -32,7 +33,7 @@ import java.util.Map;
 /**
  * Forge client event handler in the mod event bus
  */
-@Mod.EventBusSubscriber(modid = AgriApi.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
+@Mod.EventBusSubscriber(modid = AgriApi.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
 public class AgriCraftForgeClient {
 
 	@SubscribeEvent

--- a/forge/src/main/java/com/agricraft/agricraft/client/forge/ForgeBusClientEvents.java
+++ b/forge/src/main/java/com/agricraft/agricraft/client/forge/ForgeBusClientEvents.java
@@ -4,6 +4,7 @@ import com.agricraft.agricraft.api.AgriApi;
 import com.mojang.datafixers.util.Either;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RenderTooltipEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -11,7 +12,7 @@ import net.minecraftforge.fml.common.Mod;
 /**
  * Forge client event handler in the forge event bus
  */
-@Mod.EventBusSubscriber(modid = AgriApi.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+@Mod.EventBusSubscriber(modid = AgriApi.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
 public class ForgeBusClientEvents {
 
 	@SubscribeEvent

--- a/neoforge/src/main/java/com/agricraft/agricraft/client/neoforge/AgriCraftNeoForgeClient.java
+++ b/neoforge/src/main/java/com/agricraft/agricraft/client/neoforge/AgriCraftNeoForgeClient.java
@@ -19,6 +19,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.FileToIdConverter;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.Resource;
+import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
@@ -32,7 +33,7 @@ import java.util.Map;
 /**
  * NeoForge client event handler in the mod event bus
  */
-@Mod.EventBusSubscriber(modid = AgriApi.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD)
+@Mod.EventBusSubscriber(modid = AgriApi.MOD_ID, bus = Mod.EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
 public class AgriCraftNeoForgeClient {
 
 	@SubscribeEvent

--- a/neoforge/src/main/java/com/agricraft/agricraft/client/neoforge/NeoForgeBusClientEvents.java
+++ b/neoforge/src/main/java/com/agricraft/agricraft/client/neoforge/NeoForgeBusClientEvents.java
@@ -9,6 +9,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.InteractionHand;
+import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.client.event.InputEvent;
@@ -17,7 +18,7 @@ import net.neoforged.neoforge.client.event.RenderTooltipEvent;
 /**
  * NeoForge client event handler in the forge event bus
  */
-@Mod.EventBusSubscriber(modid = AgriApi.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+@Mod.EventBusSubscriber(modid = AgriApi.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
 public class NeoForgeBusClientEvents {
 
 	@SubscribeEvent


### PR DESCRIPTION
Fixes weird desyncs and plant mutation issues and a crash on dedicated servers