### PR TITLE
[1.20.4] Add config option to enable / disable AgriCraft's mod compatibility packs by default

### DIFF
--- a/common/src/main/java/com/agricraft/agricraft/api/config/CoreConfig.java
+++ b/common/src/main/java/com/agricraft/agricraft/api/config/CoreConfig.java
@@ -12,6 +12,10 @@ import com.teamresourceful.resourcefulconfig.api.types.options.EntryType;
 @Category("config.agricraft.core")
 public final class CoreConfig {
 
+	@ConfigEntry(id = "register_packs_by_default", type = EntryType.BOOLEAN, translation = "config.agricraft.core.register_packs_by_default")
+	@Comment("Set to false to prevent AgriCraft from enabling its mod compatibility datapacks / resourcepacks by default")
+	public static boolean enablePacksByDefault = true;
+
 	@ConfigEntry(id = "plant_off_crop_sticks", type = EntryType.BOOLEAN, translation = "config.agricraft.core.plant_off_crop_sticks")
 	@Comment("Set to false to disable planting of (agricraft) seeds outside crop sticks")
 	public static boolean plantOffCropSticks = true;

--- a/common/src/main/resources/assets/agricraft/lang/en_us.json
+++ b/common/src/main/resources/assets/agricraft/lang/en_us.json
@@ -156,6 +156,7 @@
   "agricraft.command.seed_distinct": "Gave %s as a seed with stats %s",
 
   "config.agricraft.core": "Core",
+  "config.agricraft.core.register_packs_by_default": "Register mod compatibility packs by default",
   "config.agricraft.core.plant_off_crop_sticks": "Plant outside crop sticks",
   "config.agricraft.core.crop_sticks_collide": "Crop sticks collide",
   "config.agricraft.core.only_fertile_crops_spread": "Only fertile crops spread/mutate",

--- a/fabric/src/main/java/com/agricraft/agricraft/fabric/AgriCraftFabric.java
+++ b/fabric/src/main/java/com/agricraft/agricraft/fabric/AgriCraftFabric.java
@@ -4,6 +4,7 @@ import com.agricraft.agricraft.AgriCraft;
 import com.agricraft.agricraft.api.AgriApi;
 import com.agricraft.agricraft.api.codecs.AgriMutation;
 import com.agricraft.agricraft.api.codecs.AgriSoil;
+import com.agricraft.agricraft.api.config.CoreConfig;
 import com.agricraft.agricraft.api.fertilizer.AgriFertilizer;
 import com.agricraft.agricraft.api.plant.AgriPlant;
 import com.agricraft.agricraft.api.plant.AgriWeed;
@@ -57,9 +58,9 @@ public class AgriCraftFabric implements ModInitializer {
 			for (ModContainer mod : FabricLoader.getInstance().getAllMods()) {
 				String modid = mod.getMetadata().getId();
 				if (!modid.equals("minecraft") && !modid.equals("agricraft")) {
-					// don't use Fabric API internals, in order to stay compatible with Quilted Fabric API
-					ResourceManagerHelper.registerBuiltinResourcePack(new ResourceLocation("builtin", "agricraft_resourcepacks_" + modid), "resourcepacks/" + modid, agricraft, true);
-					ResourceManagerHelper.registerBuiltinResourcePack(new ResourceLocation("builtin", "agricraft_datapacks_" + modid), "datapacks/" + modid, agricraft, true);
+                    // don't use Fabric API internals, in order to stay compatible with Quilted Fabric API
+					ResourceManagerHelper.registerBuiltinResourcePack(new ResourceLocation("builtin", "agricraft_resourcepacks_" + modid), "resourcepacks/" + modid, agricraft, CoreConfig.enablePacksByDefault);
+					ResourceManagerHelper.registerBuiltinResourcePack(new ResourceLocation("builtin", "agricraft_datapacks_" + modid), "datapacks/" + modid, agricraft, CoreConfig.enablePacksByDefault);
 				}
 			}
 		});

--- a/forge/src/main/java/com/agricraft/agricraft/forge/AgriCraftForge.java
+++ b/forge/src/main/java/com/agricraft/agricraft/forge/AgriCraftForge.java
@@ -4,6 +4,7 @@ import com.agricraft.agricraft.AgriCraft;
 import com.agricraft.agricraft.api.AgriApi;
 import com.agricraft.agricraft.api.codecs.AgriMutation;
 import com.agricraft.agricraft.api.codecs.AgriSoil;
+import com.agricraft.agricraft.api.config.CoreConfig;
 import com.agricraft.agricraft.api.fertilizer.AgriFertilizer;
 import com.agricraft.agricraft.api.plant.AgriPlant;
 import com.agricraft.agricraft.api.plant.AgriWeed;
@@ -116,7 +117,7 @@ public class AgriCraftForge {
 			}
 		} catch (IOException ignored) {
 		}
-		Pack pack = Pack.readMetaAndCreate(id, Component.translatable("agricraft." + type + "." + modid), false, resources, packType, Pack.Position.TOP, PackSource.BUILT_IN);
+		Pack pack = Pack.readMetaAndCreate(id, Component.translatable("agricraft." + type + "." + modid), CoreConfig.enablePacksByDefault, resources, packType, Pack.Position.TOP, PackSource.BUILT_IN);
 		if (pack != null) {
 			event.addRepositorySource(packConsumer -> packConsumer.accept(pack));
 		}


### PR DESCRIPTION
Since Forge, in their infinite wisdom, does not allow mod resource packs to be enabled by default (while still allowing disabling)