### PR TITLE
[1.20.1] Update crop block break particles

### DIFF
--- a/common/src/main/java/com/agricraft/agricraft/client/ClientUtil.java
+++ b/common/src/main/java/com/agricraft/agricraft/client/ClientUtil.java
@@ -27,23 +27,23 @@ public class ClientUtil {
 		};
 	}
 
-	public static void spawnParticlesForPlant(String plantModelId, LevelAccessor level, BlockState state, BlockPos pos) {
+	public static void spawnParticlesForPlant(String plantModelId, LevelAccessor level, BlockState state, BlockPos pos, VoxelShape voxelShape) {
 		BakedModel model = Minecraft.getInstance().getModelManager().bakedRegistry.get(new ResourceLocation(plantModelId));
-		spawnParticlesForModel(model, level, state, pos);
+		spawnParticlesForShape(model, level, state, pos, voxelShape);
 	}
 
-	public static void spawnParticlesForSticks(CropStickVariant variant, LevelAccessor level, BlockState state, BlockPos pos) {
+	public static void spawnParticlesForSticks(CropStickVariant variant, LevelAccessor level, BlockState state, BlockPos pos, VoxelShape voxelShape) {
 		String modelId = getModelForSticks(variant);
 		BakedModel model = Minecraft.getInstance().getModelManager().bakedRegistry.get(new ResourceLocation(modelId));
-		spawnParticlesForModel(model, level, state, pos);
+		spawnParticlesForShape(model, level, state, pos, voxelShape);
 	}
 
-	public static void spawnParticlesForModel(BakedModel model, LevelAccessor level, BlockState state, BlockPos pos) {
+	public static void spawnParticlesForShape(BakedModel model, LevelAccessor level, BlockState state, BlockPos pos, VoxelShape voxelShape) {
 		if (model == null) {
 			return;
 		}
 		TextureAtlasSprite particleIcon = model.getParticleIcon();
-		VoxelShape voxelShape = state.getShape(level, pos);
+
 		voxelShape.forAllBoxes((startX, startY, startZ, endX, endY, endZ) -> {
 			double xBoxes = Math.min(1.0, endX - startX);
 			double yBoxes = Math.min(1.0, endY - startY);

--- a/common/src/main/java/com/agricraft/agricraft/common/block/CropBlock.java
+++ b/common/src/main/java/com/agricraft/agricraft/common/block/CropBlock.java
@@ -73,6 +73,12 @@ public class CropBlock extends Block implements EntityBlock, BonemealableBlock, 
 			Block.box(2, 11, 0, 3, 12, 16),
 			Block.box(13, 11, 0, 14, 12, 16)
 	).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).get();
+	public static final VoxelShape CROP_STICKS = Stream.of(
+			Block.box(2, 0, 2, 3, 14, 3),
+			Block.box(13, 0, 2, 14, 14, 3),
+			Block.box(2, 0, 13, 3, 14, 14),
+			Block.box(13, 0, 13, 14, 14, 14)
+	).reduce((v1, v2) -> Shapes.join(v1, v2, BooleanOp.OR)).get();
 	public static final EnumProperty<CropStickVariant> STICK_VARIANT = EnumProperty.create("variant", CropStickVariant.class, CropStickVariant.values());
 	public static final EnumProperty<CropState> CROP_STATE = EnumProperty.create("crop", CropState.class, CropState.values());
 	public static final IntegerProperty LIGHT = IntegerProperty.create("light", 0, 16);
@@ -170,7 +176,7 @@ public class CropBlock extends Block implements EntityBlock, BonemealableBlock, 
 				return SINGLE_STICKS;
 			}
 			// shape is dependant of the plant and the weed
-			return cropState.hasSticks() ? Shapes.join(SINGLE_STICKS, cbe.getShape(), BooleanOp.OR) : cbe.getShape();
+			return cropState.hasSticks() ? Shapes.join(CROP_STICKS, cbe.getShape(), BooleanOp.OR) : cbe.getShape();
 		}
 		return super.getShape(state, level, pos, context);
 	}

--- a/common/src/main/java/com/agricraft/agricraft/common/block/CropBlock.java
+++ b/common/src/main/java/com/agricraft/agricraft/common/block/CropBlock.java
@@ -493,11 +493,17 @@ public class CropBlock extends Block implements EntityBlock, BonemealableBlock, 
 			// we handle the break particles ourselves to mimic the used model and spawn their particles instead of ours
 			CropState cropState = state.getValue(CROP_STATE);
 			if (cropState.hasSticks()) {
-				ClientUtil.spawnParticlesForSticks(state.getValue(STICK_VARIANT), level, state, pos);
+				if (cropState == CropState.DOUBLE_STICKS) {
+					ClientUtil.spawnParticlesForSticks(state.getValue(STICK_VARIANT), level, state, pos, CROSS_STICKS);
+				} else {
+					ClientUtil.spawnParticlesForSticks(state.getValue(STICK_VARIANT), level, state, pos, SINGLE_STICKS);
+				}
 			}
 			if (crop.hasPlant()) {
 				String plantModelId = crop.getPlantId().replace(":", ":crop/") + "_stage" + crop.getGrowthStage().index();
-				ClientUtil.spawnParticlesForPlant(plantModelId, level, state, pos);
+				if (level.getBlockEntity(pos) instanceof CropBlockEntity cbe) {
+					ClientUtil.spawnParticlesForPlant(plantModelId, level, state, pos, cbe.getShape());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This fixes 3 separate issues:
1. Crop sticks with crops use unnecessarily many bounding boxes,
2. Both types of particles spawn without respecting their part of the model,
3. Twice the amount of particles is spawned because of problem 2.

This fix also reduces the amount of particles spawned by breaking crop sticks with crops from up to 576 to less than 200.