### PR TITLE
[1.20.1] Fix Botania Horn Harvestable

### DIFF
--- a/common/src/main/java/com/agricraft/agricraft/common/block/CropBlock.java
+++ b/common/src/main/java/com/agricraft/agricraft/common/block/CropBlock.java
@@ -3,13 +3,13 @@ package com.agricraft.agricraft.common.block;
 import com.agricraft.agricraft.api.AgriApi;
 import com.agricraft.agricraft.api.config.CoreConfig;
 import com.agricraft.agricraft.api.crop.AgriCrop;
-import com.agricraft.agricraft.api.fertilizer.IAgriFertilizable;
 import com.agricraft.agricraft.api.genetic.AgriGenome;
 import com.agricraft.agricraft.client.ClientUtil;
 import com.agricraft.agricraft.common.block.entity.CropBlockEntity;
 import com.agricraft.agricraft.common.item.AgriSeedItem;
 import com.agricraft.agricraft.common.item.CropSticksItem;
 import com.agricraft.agricraft.common.registry.ModItems;
+import com.agricraft.agricraft.common.util.Platform;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
@@ -230,7 +230,7 @@ public class CropBlock extends Block implements EntityBlock, BonemealableBlock, 
 	@Override
 	@Nullable
 	public BlockEntity newBlockEntity(BlockPos pos, BlockState state) {
-		return new CropBlockEntity(pos, state);
+		return Platform.get().createCropBlockEntity(pos, state);
 	}
 
 	@Override

--- a/fabric/src/main/java/com/agricraft/agricraft/common/plugin/BotaniaFabricPlugin.java
+++ b/fabric/src/main/java/com/agricraft/agricraft/common/plugin/BotaniaFabricPlugin.java
@@ -1,0 +1,28 @@
+package com.agricraft.agricraft.common.plugin;
+
+import com.agricraft.agricraft.common.block.entity.CropBlockEntity;
+import com.agricraft.agricraft.common.registry.ModBlockEntityTypes;
+import com.agricraft.agricraft.compat.botania.AgriHornHarvestable;
+import com.agricraft.agricraft.compat.botania.BotaniaPlugin;
+import vazkii.botania.api.BotaniaFabricCapabilities;
+
+public class BotaniaFabricPlugin {
+
+    public static void init() {
+        BotaniaPlugin.init();
+        BotaniaFabricCapabilities.HORN_HARVEST.registerForBlockEntities((blockEntity, context) -> {
+            if (blockEntity instanceof CropBlockEntity) {
+                return AgriHornHarvestable.INSTANCE;
+            }
+            return null;
+        }, ModBlockEntityTypes.CROP.get());
+    }
+
+    public String modid() {
+        return "botania";
+    }
+
+    public String description() {
+        return "botania compatibility";
+    }
+}

--- a/fabric/src/main/java/com/agricraft/agricraft/fabric/AgriCraftFabric.java
+++ b/fabric/src/main/java/com/agricraft/agricraft/fabric/AgriCraftFabric.java
@@ -9,17 +9,14 @@ import com.agricraft.agricraft.api.config.CoreConfig;
 import com.agricraft.agricraft.api.fertilizer.AgriFertilizer;
 import com.agricraft.agricraft.api.plant.AgriPlant;
 import com.agricraft.agricraft.api.plant.AgriWeed;
-import com.agricraft.agricraft.common.block.entity.CropBlockEntity;
 import com.agricraft.agricraft.common.commands.DumpRegistriesCommand;
 import com.agricraft.agricraft.common.commands.GiveSeedCommand;
 import com.agricraft.agricraft.common.handler.DenyBonemeal;
 import com.agricraft.agricraft.common.handler.VanillaSeedConversion;
+import com.agricraft.agricraft.common.plugin.BotaniaFabricPlugin;
 import com.agricraft.agricraft.common.plugin.FabricSeasonPlugin;
-import com.agricraft.agricraft.common.registry.ModBlockEntityTypes;
 import com.agricraft.agricraft.common.util.Platform;
 import com.agricraft.agricraft.common.util.fabric.FabricPlatform;
-import com.agricraft.agricraft.compat.botania.AgriHornHarvestable;
-import com.agricraft.agricraft.compat.botania.BotaniaPlugin;
 import com.agricraft.agricraft.compat.botania.ManaGrowthCondition;
 import com.agricraft.agricraft.plugin.minecraft.MinecraftPlugin;
 import net.fabricmc.api.ModInitializer;
@@ -33,7 +30,6 @@ import net.fabricmc.loader.api.ModContainer;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.InteractionResult;
-import vazkii.botania.api.BotaniaFabricCapabilities;
 import vazkii.botania.api.mana.ManaBlockType;
 import vazkii.botania.api.mana.ManaNetworkAction;
 import vazkii.botania.api.mana.ManaNetworkCallback;
@@ -78,18 +74,12 @@ public class AgriCraftFabric implements ModInitializer {
 			}
 		});
 		if (FabricLoader.getInstance().isModLoaded("botania") && CompatConfig.enableBotania) {
-			BotaniaPlugin.init();
+			BotaniaFabricPlugin.init();
 			ManaNetworkCallback.EVENT.register((manaReceiver, manaBlockType, manaNetworkAction) -> {
 				if (manaNetworkAction == ManaNetworkAction.REMOVE && manaBlockType == ManaBlockType.POOL) {
 					ManaGrowthCondition.removePoll(manaReceiver);
 				}
 			});
-			BotaniaFabricCapabilities.HORN_HARVEST.registerForBlockEntities((blockEntity, context) -> {
-				if (blockEntity instanceof CropBlockEntity) {
-					return AgriHornHarvestable.INSTANCE;
-				}
-				return null;
-			}, ModBlockEntityTypes.CROP.get());
 		}
 	}
 


### PR DESCRIPTION
This fixes 2 bugs:
1. Fabric version crashes if there's no Botania - this was fixed by moving horn harvestable register to a separate class.
2. Newly placed crop sticks aren't horn harvestable, only after the world restart - this was caused by the fact CropBlock was creating CropBlockEntity instead of a proper platform version.