### PR TITLE
[1.20.1] Fix NPE crash in ClipperItem when clipper is automated against empty crop sticks.

### DIFF
--- a/common/src/main/java/com/agricraft/agricraft/common/item/ClipperItem.java
+++ b/common/src/main/java/com/agricraft/agricraft/common/item/ClipperItem.java
@@ -1,6 +1,7 @@
 package com.agricraft.agricraft.common.item;
 
 import com.agricraft.agricraft.api.AgriApi;
+import com.agricraft.agricraft.api.plant.AgriPlant;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
@@ -32,7 +33,11 @@ public class ClipperItem extends Item {
 		BlockPos pos = context.getClickedPos();
 		Player player = context.getPlayer();
 		return AgriApi.getCrop(level, pos).map(crop -> {
-			if (!crop.getPlant().allowsClipping(crop.getGrowthStage(), context.getItemInHand(), player)) {
+			AgriPlant plant = crop.getPlant();
+			if (plant == null) { // can happen if clipper is being automated (eg: in create deployer against empty crop sticks)
+				return InteractionResult.FAIL;
+			}
+			if (!plant.allowsClipping(crop.getGrowthStage(), context.getItemInHand(), player)) {
 				if (player != null) {
 					player.sendSystemMessage(Component.translatable("agricraft.message.clipping_impossible"));
 				}
@@ -40,11 +45,11 @@ public class ClipperItem extends Item {
 			}
 			List<ItemStack> drops = new ArrayList<>();
 			crop.getClippingProducts(drops::add, context.getItemInHand());
-			crop.setGrowthStage(crop.getPlant().getInitialGrowthStage());
+			crop.setGrowthStage(plant.getInitialGrowthStage());
 			for (ItemStack drop : drops) {
 				level.addFreshEntity(new ItemEntity(level, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, drop));
 			}
-			crop.getPlant().onClipped(crop, context.getItemInHand(), player);
+			plant.onClipped(crop, context.getItemInHand(), player);
 			return InteractionResult.SUCCESS;
 		}).orElse(InteractionResult.FAIL);
 	}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 # Project
-version=4.0.5
+version=4.0.6
 group=com.agricraft.agricraft
 
 # Common


### PR DESCRIPTION
Fixing NPE crash when using ClipperItem against a crop that has no plant (empty crop sticks).

```
Description: Ticking entity

java.lang.NullPointerException: Cannot invoke "com.agricraft.agricraft.api.plant.AgriPlant.allowsClipping(com.agricraft.agricraft.api.crop.AgriGrowthStage, net.minecraft.world.item.ItemStack, net.minecraft.world.entity.LivingEntity)" because the return value of "com.agricraft.agricraft.api.crop.AgriCrop.getPlant()" is null
        at com.agricraft.agricraft.common.item.ClipperItem.lambda$useOn$0(ClipperItem.java:35) ~[AgriCraft-forge-1.20.1-4.0.5.jar%23260!/:?] {re:classloading}
        at java.util.Optional.map(Optional.java:260) ~[?:?] {re:mixin}
        at com.agricraft.agricraft.common.item.ClipperItem.m_6225_(ClipperItem.java:34) ~[AgriCraft-forge-1.20.1-4.0.5.jar%23260!/:?] {re:classloading}
        at net.minecraftforge.common.ForgeHooks.onPlaceItemIntoWorld(ForgeHooks.java:585) ~[forge-1.20.1-47.4.0-universal.jar%23419!/:?] {re:mixin,re:classloading,pl:mixin:APP:modernfix-forge.mixins.json:perf.faster_ingredients.ForgeHooksMixin,pl:mixin:APP:lootjs-forge.mixins.json:ForgeHooksMixin,pl:mixin:A}
        at net.minecraft.world.item.ItemStack.m_41661_(ItemStack.java:245) ~[server-1.20.1-20230612.114412-srg.jar%23414!/:?] {re:mixin,xf:fml:forge:itemstack,re:classloading,xf:fml:forge:itemstack,pl:mixin:APP:itemfilters-common.mixins.json:ItemStackMixin,pl:mixin:APP:kubejs-common.mixins.json:ItemStackMixin,pl:mixin:APP:quark.mixins.json:ItemStackMixin,pl:mixin:A}
        at com.simibubi.create.content.kinetics.deployer.DeployerHandler.activateInner(DeployerHandler.java:323) ~[create-1.20.1-6.0.6.jar%23294!/:6.0.6] {re:mixin,re:classloading}
        at com.simibubi.create.content.kinetics.deployer.DeployerHandler.activate(DeployerHandler.java:138) ~[create-1.20.1-6.0.6.jar%23294!/:6.0.6] {re:mixin,re:classloading}
        at com.simibubi.create.content.kinetics.deployer.DeployerMovementBehaviour.activate(DeployerMovementBehaviour.java:115) ~[create-1.20.1-6.0.6.jar%23294!/:6.0.6] {re:mixin,re:classloading,pl:mixin:A}
```

Fix for AgriCraft 1.20.1-4.0.5.  (I'll let you make this same change in other supported branches)